### PR TITLE
Fix linter issues and cleanup code

### DIFF
--- a/src/components/EventMap.tsx
+++ b/src/components/EventMap.tsx
@@ -462,7 +462,7 @@ const EventMap = () => {
         }, 300);
       });
     });
-  }, [mapLoaded, activeCategory, selectedCounty, selectedCity, selectedPrice, selectedDateRange]);
+  }, [mapLoaded, activeCategory, selectedCounty, selectedCity, selectedPrice, selectedDateRange, events]);
   
   // Functions to handle filter changes
   const handleCategoryChange = (category: string | null) => {

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -60,11 +60,12 @@ const LoginForm = ({ mode, onToggleMode, onClose, onLoginSuccess }: LoginFormPro
         });
       }
       onLoginSuccess();
-    } catch (error: any) {
+  } catch (error: unknown) {
       console.error('Authentication error:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
       toast({
         title: 'Authentication Failed',
-        description: error.message || 'There was a problem with your login attempt.',
+        description: message || 'There was a problem with your login attempt.',
         variant: 'destructive',
       });
     } finally {
@@ -83,11 +84,12 @@ const LoginForm = ({ mode, onToggleMode, onClose, onLoginSuccess }: LoginFormPro
         description: `Welcome, ${user.displayName || user.email}!`,
       });
       onLoginSuccess();
-    } catch (error: any) {
+  } catch (error: unknown) {
       console.error('Google authentication error:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
       toast({
         title: 'Authentication Failed',
-        description: error.message || 'There was a problem with your Google login attempt.',
+        description: message || 'There was a problem with your Google login attempt.',
         variant: 'destructive',
       });
     } finally {

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -115,7 +115,7 @@ const Favorites = () => {
     }
     
     // Listen for auth state changes
-    const handleAuthChange = (e: CustomEvent) => {
+    const handleAuthChange = (e: CustomEvent<{ isLoggedIn: boolean }>) => {
       setIsLoggedIn(e.detail.isLoggedIn);
       if (!e.detail.isLoggedIn) {
         setFavoriteEvents([]);
@@ -130,10 +130,10 @@ const Favorites = () => {
       }
     };
     
-    window.addEventListener('authStateChanged' as any, handleAuthChange);
+    window.addEventListener('authStateChanged', handleAuthChange as EventListener);
     
     return () => {
-      window.removeEventListener('authStateChanged' as any, handleAuthChange);
+      window.removeEventListener('authStateChanged', handleAuthChange as EventListener);
     };
   }, []);
 

--- a/src/pages/Venues.tsx
+++ b/src/pages/Venues.tsx
@@ -214,7 +214,6 @@ const Venues = () => {
 
   const handleContactSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    console.log("Contact form submitted:", contactForm);
     
     toast({
       title: "Request Sent",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import { type Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -90,5 +91,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- improve error handling in LoginForm
- drop leftover logging in Venues page
- include events in EventMap useEffect deps
- tighten custom event types in Favorites page
- convert empty interfaces to type aliases
- use ESM import for Tailwind plugin

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841726877f08328be22576c6434e343