### PR TITLE
Use async SQLAlchemy session

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,10 +1,24 @@
 from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+
 from .config import settings
 
-engine = create_engine(settings.database_url)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+sync_engine = create_engine(settings.database_url)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=sync_engine)
+
+async_db_url = (
+    settings.database_url.replace("postgresql://", "postgresql+asyncpg://")
+    if settings.database_url.startswith("postgresql://")
+    else settings.database_url
+)
+async_engine = create_async_engine(async_db_url)
+AsyncSessionLocal = async_sessionmaker(async_engine, expire_on_commit=False)
 
 Base = declarative_base()
 
@@ -16,3 +30,9 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+async def get_async_db() -> AsyncSession:
+    """Async database dependency for FastAPI."""
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/backend/app/routes/events.py
+++ b/backend/app/routes/events.py
@@ -1,106 +1,116 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy.orm import Session
-from typing import List, Optional
 from datetime import date
+from typing import List, Optional
 
-from ..core.database import get_db
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.database import get_async_db
 from ..models.event import Event
-from ..models.schemas import Event as EventSchema, EventCreate, EventUpdate, EventResponse
+from ..models.schemas import Event as EventSchema
+from ..models.schemas import (
+    EventCreate,
+    EventResponse,
+    EventUpdate,
+)
 
 router = APIRouter(prefix="/events", tags=["events"])
 
 
 @router.get("/", response_model=EventResponse)
-def get_events(
+async def get_events(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=100),
     search: Optional[str] = Query(None),
     location: Optional[str] = Query(None),
     date_from: Optional[date] = Query(None),
     date_to: Optional[date] = Query(None),
-    db: Session = Depends(get_db)
+    db: AsyncSession = Depends(get_async_db),
 ):
     """Get all events with optional filtering and pagination."""
-    query = db.query(Event)
-    
+    stmt = select(Event)
+
     # Apply filters
     if search:
-        query = query.filter(
-            Event.name.ilike(f"%{search}%") | 
-            Event.description.ilike(f"%{search}%")
+        stmt = stmt.where(
+            Event.name.ilike(f"%{search}%") | Event.description.ilike(f"%{search}%")
         )
-    
+
     if location:
-        query = query.filter(Event.location.ilike(f"%{location}%"))
-    
+        stmt = stmt.where(Event.location.ilike(f"%{location}%"))
+
     if date_from:
-        query = query.filter(Event.date >= date_from)
-    
+        stmt = stmt.where(Event.date >= date_from)
+
     if date_to:
-        query = query.filter(Event.date <= date_to)
-    
-    # Get total count
-    total = query.count()
-    
-    # Apply pagination and ordering
-    events = query.order_by(Event.date.asc(), Event.time.asc()).offset(skip).limit(limit).all()
-    
+        stmt = stmt.where(Event.date <= date_to)
+
+    total_stmt = select(func.count()).select_from(stmt.subquery())
+    result = await db.execute(total_stmt)
+    total = result.scalar_one()
+
+    events_result = await db.execute(
+        stmt.order_by(Event.date.asc(), Event.time.asc()).offset(skip).limit(limit)
+    )
+    events = events_result.scalars().all()
+
     # Calculate pagination info
     pages = (total + limit - 1) // limit if total > 0 else 0
     page = (skip // limit) + 1 if limit > 0 else 1
-    
+
     return EventResponse(
-        events=events,
-        total=total,
-        page=page,
-        size=len(events),
-        pages=pages
+        events=events, total=total, page=page, size=len(events), pages=pages
     )
 
 
 @router.get("/{event_id}", response_model=EventSchema)
-def get_event(event_id: int, db: Session = Depends(get_db)):
+async def get_event(event_id: int, db: AsyncSession = Depends(get_async_db)):
     """Get a specific event by ID."""
-    event = db.query(Event).filter(Event.id == event_id).first()
+    result = await db.execute(select(Event).where(Event.id == event_id))
+    event = result.scalar_one_or_none()
     if not event:
         raise HTTPException(status_code=404, detail="Event not found")
     return event
 
 
 @router.post("/", response_model=EventSchema)
-def create_event(event: EventCreate, db: Session = Depends(get_db)):
+async def create_event(event: EventCreate, db: AsyncSession = Depends(get_async_db)):
     """Create a new event."""
     db_event = Event(**event.model_dump())
     db.add(db_event)
-    db.commit()
-    db.refresh(db_event)
+    await db.commit()
+    await db.refresh(db_event)
     return db_event
 
 
 @router.put("/{event_id}", response_model=EventSchema)
-def update_event(event_id: int, event: EventUpdate, db: Session = Depends(get_db)):
+async def update_event(
+    event_id: int, event: EventUpdate, db: AsyncSession = Depends(get_async_db)
+):
     """Update an existing event."""
-    db_event = db.query(Event).filter(Event.id == event_id).first()
+    result = await db.execute(select(Event).where(Event.id == event_id))
+    db_event = result.scalar_one_or_none()
     if not db_event:
         raise HTTPException(status_code=404, detail="Event not found")
-    
+
     # Update only provided fields
     update_data = event.model_dump(exclude_unset=True)
     for field, value in update_data.items():
         setattr(db_event, field, value)
-    
-    db.commit()
-    db.refresh(db_event)
+
+    await db.commit()
+    await db.refresh(db_event)
     return db_event
 
 
 @router.delete("/{event_id}")
-def delete_event(event_id: int, db: Session = Depends(get_db)):
+async def delete_event(event_id: int, db: AsyncSession = Depends(get_async_db)):
     """Delete an event."""
-    db_event = db.query(Event).filter(Event.id == event_id).first()
+    result = await db.execute(select(Event).where(Event.id == event_id))
+    db_event = result.scalar_one_or_none()
     if not db_event:
         raise HTTPException(status_code=404, detail="Event not found")
-    
-    db.delete(db_event)
-    db.commit()
+
+    await db.delete(db_event)
+    await db.commit()
     return {"message": "Event deleted successfully"}


### PR DESCRIPTION
## Summary
- make database connection async capable
- convert events router to use AsyncSession

## Testing
- `pytest test_server.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b9a71eec832894e7b2c2ce65a797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced asynchronous database support, allowing faster and more scalable event operations.
- **Refactor**
	- Updated all event-related endpoints to use asynchronous database sessions for improved performance and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->