### PR TITLE
Add Celery worker for background scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ docker-compose down -v && docker-compose up --build
 ├─────────────────┤
 │   Backend API   │ :8000 (FastAPI + Python)
 ├─────────────────┤
+│   Celery Worker │ (Background tasks)
+├─────────────────┤
 │   PostgreSQL    │ :5432 (Database)
 ├─────────────────┤
 │   Redis         │ :6379 (Cache)
@@ -75,6 +77,7 @@ docker-compose down -v && docker-compose up --build
 ### Services
 - **Frontend**: React + TypeScript + Vite served by Nginx
 - **Backend**: FastAPI + SQLAlchemy + Python with uv
+- **Celery**: Background worker for scraping tasks
 - **Database**: PostgreSQL 15 with sample Croatian events
 - **Cache**: Redis 7 for caching and task queues
 - **Proxy**: Nginx reverse proxy with load balancing
@@ -210,6 +213,7 @@ The backend includes an integrated web scraping system that automatically collec
 - **Automatic Data Processing**: Transforms scraped data to match database schema
 - **Duplicate Prevention**: Automatically detects and prevents duplicate events
 - **Scheduled Tasks**: Optional automatic scraping at configurable intervals
+- **Celery Queue**: Heavy scraping jobs run in a Celery worker using Redis
 
 ### Usage
 
@@ -353,6 +357,9 @@ USE_PLAYWRIGHT=true
 # BrightData (optional, for proxy scraping)
 BRIGHTDATA_USER=your-brightdata-user
 BRIGHTDATA_PASSWORD=your-brightdata-password
+# Celery
+CELERY_BROKER_URL=redis://localhost:6379/0
+CELERY_RESULT_BACKEND=redis://localhost:6379/0
 ```
 
 ### Frontend (`.env`)

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -1,0 +1,13 @@
+import os
+
+from celery import Celery
+
+from .core.config import settings
+
+broker_url = os.getenv("CELERY_BROKER_URL", settings.redis_url)
+backend_url = os.getenv("CELERY_RESULT_BACKEND", settings.redis_url)
+
+celery_app = Celery("kruzna_karta", broker=broker_url, backend=backend_url)
+
+# Route scraping tasks to a dedicated queue
+celery_app.conf.task_routes = {"app.tasks.celery_tasks.*": {"queue": "scraping"}}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,5 +1,6 @@
-from pydantic_settings import BaseSettings
 from typing import Optional
+
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
@@ -23,6 +24,12 @@ class Settings(BaseSettings):
     secret_key: str
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 30
+
+    # Redis / Celery
+    redis_url: str = "redis://localhost:6379/0"
+
+    celery_broker_url: Optional[str] = None
+    celery_result_backend: Optional[str] = None
 
     class Config:
         env_file = ".env"

--- a/backend/app/routes/scraping.py
+++ b/backend/app/routes/scraping.py
@@ -1,10 +1,16 @@
-from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
-from pydantic import BaseModel
-from typing import Optional
 import asyncio
+from typing import Optional
 
-from ..scraping.entrio_scraper import scrape_entrio_events
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
 from ..scraping.croatia_scraper import scrape_croatia_events
+from ..scraping.entrio_scraper import scrape_entrio_events
+from ..tasks.celery_tasks import (
+    scrape_all_sites_task,
+    scrape_croatia_task,
+    scrape_entrio_task,
+)
 
 router = APIRouter(prefix="/scraping", tags=["scraping"])
 
@@ -22,24 +28,8 @@ class ScrapeRequest(BaseModel):
     use_playwright: bool = True
 
 
-async def run_scraping_task(max_pages: int, task_id: str):
-    """Background task to run scraping."""
-    try:
-        result = await scrape_entrio_events(max_pages=max_pages)
-        # In a real implementation, you'd store this result somewhere
-        # accessible by task_id (Redis, database, etc.)
-        print(f"Scraping task {task_id} completed: {result}")
-        return result
-    except Exception as e:
-        print(f"Scraping task {task_id} failed: {e}")
-        return {"status": "error", "message": str(e)}
-
-
 @router.post("/entrio", response_model=ScrapeResponse)
-async def scrape_entrio(
-    request: ScrapeRequest,
-    background_tasks: BackgroundTasks
-):
+async def scrape_entrio(request: ScrapeRequest):
     """
     Trigger Entrio.hr event scraping.
     This will scrape events and save them to the database.
@@ -49,30 +39,26 @@ async def scrape_entrio(
         if request.max_pages <= 2:
             result = await scrape_entrio_events(max_pages=request.max_pages)
             return ScrapeResponse(**result)
-        
-        # For larger scraping jobs, run in background
-        import uuid
-        task_id = str(uuid.uuid4())
-        
-        background_tasks.add_task(
-            run_scraping_task, 
-            max_pages=request.max_pages,
-            task_id=task_id
-        )
-        
+
+        # For larger scraping jobs, delegate to Celery
+        task = scrape_entrio_task.delay(max_pages=request.max_pages)
         return ScrapeResponse(
             status="accepted",
-            message=f"Scraping task started in background for {request.max_pages} pages",
-            task_id=task_id
+            message=f"Scraping task queued for {request.max_pages} pages",
+            task_id=task.id,
         )
-    
+
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to start scraping: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to start scraping: {str(e)}"
+        )
 
 
 @router.get("/entrio/quick", response_model=ScrapeResponse)
 async def quick_scrape_entrio(
-    max_pages: int = Query(1, ge=1, le=3, description="Number of pages to scrape (1-3 for quick scraping)")
+    max_pages: int = Query(
+        1, ge=1, le=3, description="Number of pages to scrape (1-3 for quick scraping)"
+    )
 ):
     """
     Quick Entrio.hr event scraping for immediate results.
@@ -81,16 +67,13 @@ async def quick_scrape_entrio(
     try:
         result = await scrape_entrio_events(max_pages=max_pages)
         return ScrapeResponse(**result)
-    
+
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Scraping failed: {str(e)}")
 
 
 @router.post("/croatia", response_model=ScrapeResponse)
-async def scrape_croatia(
-    request: ScrapeRequest,
-    background_tasks: BackgroundTasks
-):
+async def scrape_croatia(request: ScrapeRequest):
     """
     Trigger Croatia.hr event scraping.
     This will scrape events from https://croatia.hr/hr-hr/dogadanja and save them to the database.
@@ -100,29 +83,26 @@ async def scrape_croatia(
         if request.max_pages <= 2:
             result = await scrape_croatia_events(max_pages=request.max_pages)
             return ScrapeResponse(**result)
-        
-        # For larger scraping jobs, run in background
-        import uuid
-        task_id = str(uuid.uuid4())
-        
-        async def run_croatia_scraping_task():
-            return await scrape_croatia_events(max_pages=request.max_pages)
-        
-        background_tasks.add_task(run_croatia_scraping_task)
-        
+
+        # For larger scraping jobs, delegate to Celery
+        task = scrape_croatia_task.delay(max_pages=request.max_pages)
         return ScrapeResponse(
             status="accepted",
-            message=f"Croatia.hr scraping task started in background for {request.max_pages} pages",
-            task_id=task_id
+            message=f"Croatia.hr scraping task queued for {request.max_pages} pages",
+            task_id=task.id,
         )
-    
+
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to start Croatia.hr scraping: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to start Croatia.hr scraping: {str(e)}"
+        )
 
 
 @router.get("/croatia/quick", response_model=ScrapeResponse)
 async def quick_scrape_croatia(
-    max_pages: int = Query(1, ge=1, le=3, description="Number of pages to scrape (1-3 for quick scraping)")
+    max_pages: int = Query(
+        1, ge=1, le=3, description="Number of pages to scrape (1-3 for quick scraping)"
+    )
 ):
     """
     Quick Croatia.hr event scraping for immediate results.
@@ -131,83 +111,61 @@ async def quick_scrape_croatia(
     try:
         result = await scrape_croatia_events(max_pages=max_pages)
         return ScrapeResponse(**result)
-    
+
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Croatia.hr scraping failed: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Croatia.hr scraping failed: {str(e)}"
+        )
 
 
 @router.post("/all", response_model=ScrapeResponse)
-async def scrape_all_sites(
-    request: ScrapeRequest,
-    background_tasks: BackgroundTasks
-):
+async def scrape_all_sites(request: ScrapeRequest):
     """
     Trigger scraping from all supported sites (Entrio.hr and Croatia.hr).
     This will scrape events from both sites and save them to the database.
     """
     try:
-        import uuid
-        task_id = str(uuid.uuid4())
-        
-        async def run_all_scraping_tasks():
-            results = []
-            try:
-                # Scrape Entrio.hr
-                entrio_result = await scrape_entrio_events(max_pages=request.max_pages)
-                results.append(("Entrio.hr", entrio_result))
-                
-                # Scrape Croatia.hr
-                croatia_result = await scrape_croatia_events(max_pages=request.max_pages)
-                results.append(("Croatia.hr", croatia_result))
-                
-                # Combine results
-                total_scraped = sum(result[1].get("scraped_events", 0) for result in results)
-                total_saved = sum(result[1].get("saved_events", 0) for result in results)
-                
-                return {
-                    "status": "success",
-                    "scraped_events": total_scraped,
-                    "saved_events": total_saved,
-                    "message": f"Scraped from all sites: {total_scraped} events total, {total_saved} new events saved",
-                    "details": {site: result for site, result in results}
-                }
-            except Exception as e:
-                return {
-                    "status": "error",
-                    "message": f"Multi-site scraping failed: {str(e)}",
-                    "details": results
-                }
-        
         # For small requests, run immediately
         if request.max_pages <= 2:
-            result = await run_all_scraping_tasks()
-            return ScrapeResponse(**result)
-        
-        # For larger requests, run in background
-        background_tasks.add_task(run_all_scraping_tasks)
-        
+            results = await asyncio.gather(
+                scrape_entrio_events(max_pages=request.max_pages),
+                scrape_croatia_events(max_pages=request.max_pages),
+            )
+            total_scraped = sum(r.get("scraped_events", 0) for r in results)
+            total_saved = sum(r.get("saved_events", 0) for r in results)
+            return ScrapeResponse(
+                status="success",
+                message=f"Scraped from all sites: {total_scraped} events total, {total_saved} new events saved",
+                scraped_events=total_scraped,
+                saved_events=total_saved,
+            )
+
+        task = scrape_all_sites_task.delay(max_pages=request.max_pages)
         return ScrapeResponse(
             status="accepted",
-            message=f"Multi-site scraping task started for {request.max_pages} pages per site",
-            task_id=task_id
+            message=f"Multi-site scraping task queued for {request.max_pages} pages per site",
+            task_id=task.id,
         )
-    
+
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to start multi-site scraping: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to start multi-site scraping: {str(e)}"
+        )
 
 
 @router.get("/status")
 async def scraping_status():
     """Get scraping system status and configuration."""
     import os
-    
+
     config = {
         "use_proxy": os.getenv("USE_PROXY", "0") == "1",
         "use_playwright": os.getenv("USE_PLAYWRIGHT", "1") == "1",
         "use_scraping_browser": os.getenv("USE_SCRAPING_BROWSER", "0") == "1",
-        "brightdata_configured": bool(os.getenv("BRIGHTDATA_USER")) and bool(os.getenv("BRIGHTDATA_PASSWORD")),
+        "brightdata_configured": bool(os.getenv("BRIGHTDATA_USER"))
+        and bool(os.getenv("BRIGHTDATA_PASSWORD")),
     }
-    
+
     return {
         "status": "operational",
         "config": config,
@@ -218,6 +176,6 @@ async def scraping_status():
             "POST /scraping/croatia": "Croatia.hr full scraping with background processing",
             "GET /scraping/croatia/quick": "Croatia.hr quick scraping (1-3 pages)",
             "POST /scraping/all": "Scrape all supported sites",
-            "GET /scraping/status": "System status"
-        }
+            "GET /scraping/status": "System status",
+        },
     }

--- a/backend/app/tasks/celery_tasks.py
+++ b/backend/app/tasks/celery_tasks.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from ..celery_app import celery_app
+from ..scraping.croatia_scraper import scrape_croatia_events
+from ..scraping.entrio_scraper import scrape_entrio_events
+
+
+@celery_app.task(name="scrape_entrio")
+def scrape_entrio_task(max_pages: int = 5):
+    try:
+        return asyncio.run(scrape_entrio_events(max_pages=max_pages))
+    except Exception as e:
+        return {"status": "error", "message": str(e)}
+
+
+@celery_app.task(name="scrape_croatia")
+def scrape_croatia_task(max_pages: int = 5):
+    try:
+        return asyncio.run(scrape_croatia_events(max_pages=max_pages))
+    except Exception as e:
+        return {"status": "error", "message": str(e)}
+
+
+@celery_app.task(name="scrape_all_sites")
+def scrape_all_sites_task(max_pages: int = 5):
+    results = []
+    try:
+        entrio_result = asyncio.run(scrape_entrio_events(max_pages=max_pages))
+        results.append(("Entrio.hr", entrio_result))
+        croatia_result = asyncio.run(scrape_croatia_events(max_pages=max_pages))
+        results.append(("Croatia.hr", croatia_result))
+        total_scraped = sum(r[1].get("scraped_events", 0) for r in results)
+        total_saved = sum(r[1].get("saved_events", 0) for r in results)
+        return {
+            "status": "success",
+            "scraped_events": total_scraped,
+            "saved_events": total_saved,
+            "details": {site: r for site, r in results},
+        }
+    except Exception as e:
+        return {"status": "error", "message": str(e), "details": results}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,29 @@ services:
     networks:
       - diidemo-network
 
+  celery:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: diidemo-celery
+    command: celery -A app.celery_app.celery_app worker --loglevel=info
+    environment:
+      - DATABASE_URL=postgresql://postgres:diidemo2024@postgres:5432/kruzna_karta_hrvatska
+      - REDIS_URL=redis://redis:6379/0
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - SECRET_KEY=diidemo-secret-key-2024
+      - DEBUG=false
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - ./backend/app:/app/app
+    networks:
+      - diidemo-network
+
   # Frontend
   frontend:
     build:


### PR DESCRIPTION
## Summary
- add Celery application and scraping tasks
- queue scraping jobs through Celery instead of FastAPI background tasks
- expose new celery service in docker-compose
- document Celery worker and environment variables
- support redis config in settings

## Testing
- `npm run test` *(fails: ValidationError: database_url field required)*
- `make format-backend`


------
https://chatgpt.com/codex/tasks/task_e_6845b9c83a688328ada49a17e046d7d5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a background worker service for handling large event scraping tasks, improving scalability and performance.
  - Added support for distributed task processing, enabling heavy scraping jobs to run asynchronously without blocking the main application.

- **Documentation**
  - Updated documentation to reflect the addition of the background worker service and new environment variables for configuration.

- **Chores**
  - Enhanced deployment setup by adding a dedicated background worker service to the application’s container orchestration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->