### PR TITLE
Centralize environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Global environment configuration for Kruzna Karta Hrvatska
+
+# Backend settings
+DATABASE_URL=postgresql://username:password@localhost:5432/kruzna_karta_hrvatska
+SECRET_KEY=your-secret-key-here
+DEBUG=True
+FRONTEND_URL=http://localhost:5173
+
+# Scraping configuration
+ENABLE_SCHEDULER=false
+USE_PROXY=false
+USE_PLAYWRIGHT=true
+USE_SCRAPING_BROWSER=false
+BRIGHTDATA_USER=
+BRIGHTDATA_PASSWORD=
+BRIGHTDATA_PORT=22225
+CATEGORY_URL=https://www.entrio.hr/hr/
+
+# Frontend settings
+VITE_API_BASE_URL=http://localhost:8000/api
+VITE_MAPBOX_ACCESS_TOKEN=your_mapbox_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Thumbs.db
 
 # Environment files
 .env
+!.env.example
 .env.*
 
 # TypeScript

--- a/README.md
+++ b/README.md
@@ -141,11 +141,10 @@ npm run setup
 # 1. Create PostgreSQL database
 createdb kruzna_karta_hrvatska
 
-# 2. Copy environment files and configure
-cp backend/.env.example backend/.env
-cp frontend/.env.example frontend/.env
+# 2. Copy environment file and configure
+cp .env.example .env
 
-# 3. Edit backend/.env with your database credentials:
+# 3. Edit `.env` with your database credentials:
 # DATABASE_URL=postgresql://username:password@localhost:5432/kruzna_karta_hrvatska
 
 # 4. Run database setup script
@@ -338,25 +337,26 @@ Visit http://localhost:8000/docs for interactive API documentation (Swagger UI).
 
 ## 🔐 Environment Variables
 
-### Backend (`.env`)
+All services use a shared `.env` file located in the project root. Create it by
+copying `.env.example` and adjusting the values:
+
 ```env
 DATABASE_URL=postgresql://username:password@localhost:5432/kruzna_karta_hrvatska
 SECRET_KEY=your-secret-key-here
 DEBUG=True
 FRONTEND_URL=http://localhost:5173
 
-# Scraping Configuration
+# Scraping configuration
 ENABLE_SCHEDULER=false
 USE_PROXY=false
 USE_PLAYWRIGHT=true
+USE_SCRAPING_BROWSER=false
+BRIGHTDATA_USER=
+BRIGHTDATA_PASSWORD=
+BRIGHTDATA_PORT=22225
+CATEGORY_URL=https://www.entrio.hr/hr/
 
-# BrightData (optional, for proxy scraping)
-BRIGHTDATA_USER=your-brightdata-user
-BRIGHTDATA_PASSWORD=your-brightdata-password
-```
-
-### Frontend (`.env`)
-```env
+# Frontend
 VITE_API_BASE_URL=http://localhost:8000/api
 VITE_MAPBOX_ACCESS_TOKEN=your_mapbox_token_here
 ```

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from pydantic_settings import BaseSettings
 from typing import Optional
 
@@ -24,9 +25,30 @@ class Settings(BaseSettings):
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 30
 
+    # Scraping settings
+    enable_scheduler: bool = False
+    use_proxy: bool = False
+    use_playwright: bool = True
+    use_scraping_browser: bool = False
+    brightdata_user: Optional[str] = None
+    brightdata_password: Optional[str] = None
+    brightdata_port: int = 22225
+    category_url: str = "https://www.entrio.hr/hr/"
+
     class Config:
-        env_file = ".env"
+        env_file = Path(__file__).resolve().parents[2] / ".env"
         case_sensitive = False
 
 
 settings = Settings()
+
+
+def validate_settings(cfg: Settings) -> None:
+    """Validate critical configuration values."""
+    if cfg.use_proxy and (not cfg.brightdata_user or not cfg.brightdata_password):
+        raise ValueError(
+            "USE_PROXY requires BRIGHTDATA_USER and BRIGHTDATA_PASSWORD to be set"
+        )
+
+
+validate_settings(settings)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
-import os
 
 from .core.config import settings
 from .routes import events_router, scraping_router
@@ -14,7 +13,7 @@ async def lifespan(app: FastAPI):
     print("Starting Kruzna Karta Hrvatska API...")
     
     # Start scheduler if enabled
-    enable_scheduler = os.getenv("ENABLE_SCHEDULER", "false").lower() == "true"
+    enable_scheduler = settings.enable_scheduler
     if enable_scheduler:
         from .tasks.scheduler import start_scheduler
         development = settings.debug

--- a/backend/app/routes/scraping.py
+++ b/backend/app/routes/scraping.py
@@ -199,13 +199,14 @@ async def scrape_all_sites(
 @router.get("/status")
 async def scraping_status():
     """Get scraping system status and configuration."""
-    import os
-    
+
+    from ..core.config import settings
+
     config = {
-        "use_proxy": os.getenv("USE_PROXY", "0") == "1",
-        "use_playwright": os.getenv("USE_PLAYWRIGHT", "1") == "1",
-        "use_scraping_browser": os.getenv("USE_SCRAPING_BROWSER", "0") == "1",
-        "brightdata_configured": bool(os.getenv("BRIGHTDATA_USER")) and bool(os.getenv("BRIGHTDATA_PASSWORD")),
+        "use_proxy": settings.use_proxy,
+        "use_playwright": settings.use_playwright,
+        "use_scraping_browser": settings.use_scraping_browser,
+        "brightdata_configured": bool(settings.brightdata_user) and bool(settings.brightdata_password),
     }
     
     return {

--- a/backend/app/scraping/croatia_scraper.py
+++ b/backend/app/scraping/croatia_scraper.py
@@ -5,7 +5,6 @@ This scraper handles the Vue.js-based dynamic content and extracts event informa
 
 import asyncio
 import json
-import os
 import time
 import re
 from datetime import date, datetime
@@ -22,17 +21,17 @@ from ..models.event import Event
 from ..models.schemas import EventCreate
 
 # BrightData configuration (reuse from entrio scraper)
-USER = os.getenv("BRIGHTDATA_USER", "demo_user")
-PASSWORD = os.getenv("BRIGHTDATA_PASSWORD", "demo_password")
+USER = settings.brightdata_user or "demo_user"
+PASSWORD = settings.brightdata_password or "demo_password"
 BRIGHTDATA_HOST_RES = "brd.superproxy.io"
-BRIGHTDATA_PORT = int(os.getenv("BRIGHTDATA_PORT", 22225))
+BRIGHTDATA_PORT = settings.brightdata_port
 SCRAPING_BROWSER_EP = f"https://brd.superproxy.io:{BRIGHTDATA_PORT}"
 PROXY = f"http://{USER}:{PASSWORD}@{BRIGHTDATA_HOST_RES}:{BRIGHTDATA_PORT}"
 BRD_WSS = f"wss://{USER}:{PASSWORD}@brd.superproxy.io:9222"
 
-USE_SB = os.getenv("USE_SCRAPING_BROWSER", "0") == "1"
-USE_PROXY = os.getenv("USE_PROXY", "0") == "1"
-USE_PLAYWRIGHT = os.getenv("USE_PLAYWRIGHT", "1") == "1"
+USE_SB = settings.use_scraping_browser
+USE_PROXY = settings.use_proxy
+USE_PLAYWRIGHT = settings.use_playwright
 
 HEADERS = {
     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",

--- a/backend/app/scraping/entrio_scraper.py
+++ b/backend/app/scraping/entrio_scraper.py
@@ -5,7 +5,6 @@ Combines both BrightData proxy and Playwright approaches.
 
 import asyncio
 import json
-import os
 import time
 import re
 from datetime import date, datetime
@@ -22,18 +21,18 @@ from ..models.event import Event
 from ..models.schemas import EventCreate
 
 # BrightData configuration
-USER = os.getenv("BRIGHTDATA_USER", "demo_user")
-PASSWORD = os.getenv("BRIGHTDATA_PASSWORD", "demo_password")
+USER = settings.brightdata_user or "demo_user"
+PASSWORD = settings.brightdata_password or "demo_password"
 BRIGHTDATA_HOST_RES = "brd.superproxy.io"
-BRIGHTDATA_PORT = int(os.getenv("BRIGHTDATA_PORT", 22225))
+BRIGHTDATA_PORT = settings.brightdata_port
 SCRAPING_BROWSER_EP = f"https://brd.superproxy.io:{BRIGHTDATA_PORT}"
 PROXY = f"http://{USER}:{PASSWORD}@{BRIGHTDATA_HOST_RES}:{BRIGHTDATA_PORT}"
 BRD_WSS = f"wss://{USER}:{PASSWORD}@brd.superproxy.io:9222"
 
-CATEGORY_URL = os.getenv("CATEGORY_URL", "https://www.entrio.hr/hr/")
-USE_SB = os.getenv("USE_SCRAPING_BROWSER", "0") == "1"
-USE_PROXY = os.getenv("USE_PROXY", "0") == "1"
-USE_PLAYWRIGHT = os.getenv("USE_PLAYWRIGHT", "1") == "1"
+CATEGORY_URL = settings.category_url
+USE_SB = settings.use_scraping_browser
+USE_PROXY = settings.use_proxy
+USE_PLAYWRIGHT = settings.use_playwright
 
 HEADERS = {
     "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 ScraperBot/1.0"


### PR DESCRIPTION
## Summary
- add root `.env.example`
- load settings from shared `.env` and validate on startup
- reference scraper config values through centralized settings
- update README for single `.env` file
- allow checking `.env.example` in gitignore

## Testing
- `npm run test` *(fails: async test plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845b9d2620083288d9e3e99407e3d5e