### PR TITLE
Add OAuth2 authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,11 @@ The backend provides RESTful API endpoints:
 - `POST /api/scraping/all` - Scrape from all supported sites
 - `GET /api/scraping/status` - Get scraping system status
 
+### Authentication
+- `POST /api/auth/register` - Register a new user
+- `POST /api/auth/login` - Obtain an access token
+- `POST /api/auth/refresh` - Refresh an existing token
+
 ### API Documentation
 Visit http://localhost:8000/docs for interactive API documentation (Swagger UI).
 
@@ -342,6 +347,8 @@ Visit http://localhost:8000/docs for interactive API documentation (Swagger UI).
 ```env
 DATABASE_URL=postgresql://username:password@localhost:5432/kruzna_karta_hrvatska
 SECRET_KEY=your-secret-key-here
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30
 DEBUG=True
 FRONTEND_URL=http://localhost:5173
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from jose import jwt, JWTError
+from passlib.context import CryptContext
+
+from .config import settings
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (
+        expires_delta or timedelta(minutes=settings.access_token_expire_minutes)
+    )
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
+    return encoded_jwt
+
+
+def decode_token(token: str) -> Optional[dict]:
+    try:
+        payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+        return payload
+    except JWTError:
+        return None
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ import os
 
 from .core.config import settings
 from .routes import events_router, scraping_router
+from .routes.auth import router as auth_router
 
 
 @asynccontextmanager
@@ -48,6 +49,7 @@ app.add_middleware(
 # Include routers
 app.include_router(events_router, prefix="/api")
 app.include_router(scraping_router, prefix="/api")
+app.include_router(auth_router, prefix="/api")
 
 @app.get("/")
 def read_root():

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
 from .event import Event
+from .user import User
 
-__all__ = ["Event"]
+__all__ = ["Event", "User"]

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -44,3 +44,26 @@ class EventResponse(BaseModel):
     page: int
     size: int
     pages: int
+
+
+class UserBase(BaseModel):
+    email: str
+    full_name: Optional[str] = None
+
+
+class UserCreate(UserBase):
+    password: str
+
+
+class User(UserBase):
+    id: int
+    is_active: bool
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, Integer, String, Boolean, DateTime
+from sqlalchemy.sql import func
+
+from ..core.database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String(255), unique=True, index=True, nullable=False)
+    full_name = Column(String(255))
+    hashed_password = Column(String(255), nullable=False)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,0 +1,56 @@
+from datetime import timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
+from ..core.database import get_db
+from ..core.security import (
+    verify_password,
+    get_password_hash,
+    create_access_token,
+    decode_token,
+)
+from ..models.user import User
+from ..models.schemas import UserCreate, User as UserSchema, Token
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+def authenticate_user(db: Session, email: str, password: str) -> User | None:
+    user = db.query(User).filter(User.email == email).first()
+    if not user or not verify_password(password, user.hashed_password):
+        return None
+    return user
+
+
+@router.post("/register", response_model=UserSchema)
+def register(user_in: UserCreate, db: Session = Depends(get_db)):
+    existing = db.query(User).filter(User.email == user_in.email).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Email already registered")
+    hashed_password = get_password_hash(user_in.password)
+    user = User(email=user_in.email, full_name=user_in.full_name, hashed_password=hashed_password)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@router.post("/login", response_model=Token)
+def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
+    user = authenticate_user(db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect email or password")
+    access_token = create_access_token({"sub": str(user.id)})
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.post("/refresh", response_model=Token)
+def refresh(token: Token, db: Session = Depends(get_db)):
+    payload = decode_token(token.access_token)
+    if not payload or "sub" not in payload:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    new_token = create_access_token({"sub": payload["sub"]})
+    return {"access_token": new_token, "token_type": "bearer"}
+

--- a/backend/scripts/setup_database.py
+++ b/backend/scripts/setup_database.py
@@ -15,7 +15,9 @@ from sqlalchemy import create_engine
 from app.core.config import settings
 from app.core.database import Base
 from app.models.event import Event
+from app.models.user import User
 from app.core.database import SessionLocal
+from app.core.security import get_password_hash
 
 
 def create_tables():
@@ -97,6 +99,13 @@ def insert_sample_data():
 
         db.commit()
         print("Sample data inserted successfully!")
+
+        # Create a default user
+        hashed_password = get_password_hash("password123")
+        user = User(email="demo@example.com", full_name="Demo User", hashed_password=hashed_password)
+        db.add(user)
+        db.commit()
+        print("Created demo user: demo@example.com / password123")
 
     except Exception as e:
         print(f"Error inserting sample data: {e}")


### PR DESCRIPTION
## Summary
- implement basic auth routes for registering and logging in
- hash passwords and generate JWT tokens
- add a user model and create a demo user in setup script
- expose auth router in FastAPI main app
- document auth endpoints and JWT settings in README

## Testing
- `make test` *(fails: Missing frontend test script)*
- `make test-backend` *(fails: ValidationError for missing env variables)*


------
https://chatgpt.com/codex/tasks/task_e_6845b9df084c8328b914366de11e379b