### PR TITLE
Add Redis cache and PostgreSQL full‑text search

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ docker-compose down -v && docker-compose up --build
 - **Frontend**: React + TypeScript + Vite served by Nginx
 - **Backend**: FastAPI + SQLAlchemy + Python with uv
 - **Database**: PostgreSQL 15 with sample Croatian events
-- **Cache**: Redis 7 for caching and task queues
+- **Cache**: Redis 7 used for caching frequent event queries and task queues
 - **Proxy**: Nginx reverse proxy with load balancing
 
 ## 🏗️ Project Structure
@@ -210,6 +210,8 @@ The backend includes an integrated web scraping system that automatically collec
 - **Automatic Data Processing**: Transforms scraped data to match database schema
 - **Duplicate Prevention**: Automatically detects and prevents duplicate events
 - **Scheduled Tasks**: Optional automatic scraping at configurable intervals
+- **Redis Caching**: Frequently requested event lists are cached in Redis
+- **Full-Text Search**: PostgreSQL full-text index for efficient search
 
 ### Usage
 
@@ -319,7 +321,7 @@ uv run pytest                          # Run tests
 The backend provides RESTful API endpoints:
 
 ### Events
-- `GET /api/events` - Get all events (with filtering & pagination)
+- `GET /api/events` - Get all events (supports full-text search & caching)
 - `GET /api/events/{id}` - Get specific event
 - `POST /api/events` - Create new event
 - `PUT /api/events/{id}` - Update event
@@ -396,7 +398,7 @@ npm run build
 
 ### Database Migrations
 
-The project uses SQLAlchemy. For schema changes:
+The backend uses Alembic for migrations. For schema changes:
 
 ```bash
 cd backend

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,48 @@
+import os
+import sys
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app.core.config import settings
+from app.core.database import Base
+
+config = context.config
+fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline():
+    url = settings.database_url
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        {"sqlalchemy.url": settings.database_url},
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/versions/0001_add_search_vector.py
+++ b/backend/alembic/versions/0001_add_search_vector.py
@@ -1,0 +1,19 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('events', sa.Column('search_vector', postgresql.TSVECTOR(), nullable=True))
+    op.execute("UPDATE events SET search_vector = to_tsvector('simple', coalesce(name,'') || ' ' || coalesce(description,''))")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_events_search ON events USING GIN(search_vector)")
+    op.execute("""CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON events FOR EACH ROW EXECUTE FUNCTION tsvector_update_trigger(search_vector, 'pg_catalog.simple', name, description)""")
+
+def downgrade():
+    op.execute("DROP TRIGGER IF EXISTS tsvectorupdate ON events")
+    op.drop_index('idx_events_search', table_name='events')
+    op.drop_column('events', 'search_vector')

--- a/backend/app/core/cache.py
+++ b/backend/app/core/cache.py
@@ -1,0 +1,9 @@
+import redis
+
+from .config import settings
+
+redis_client = redis.Redis.from_url(settings.redis_url, decode_responses=True)
+
+
+def get_cache():
+    return redis_client

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,10 +1,12 @@
-from pydantic_settings import BaseSettings
 from typing import Optional
+
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
     # Database settings
     database_url: str
+    redis_url: str = "redis://localhost:6379/0"
     db_host: str = "localhost"
     db_port: int = 5432
     db_name: str = "kruzna_karta_hrvatska"

--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -1,5 +1,7 @@
-from sqlalchemy import Column, Integer, String, Date, DateTime, Text
+from sqlalchemy import Column, Date, DateTime, Integer, String, Text
+from sqlalchemy.dialects.postgresql import TSVECTOR
 from sqlalchemy.sql import func
+
 from ..core.database import Base
 
 
@@ -15,5 +17,8 @@ class Event(Base):
     price = Column(String(50))
     image = Column(String(500))
     link = Column(String(500))
+    search_vector = Column(TSVECTOR)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/app/routes/events.py
+++ b/backend/app/routes/events.py
@@ -1,11 +1,20 @@
+import json
+from datetime import date
+from typing import Optional
+
+import sqlalchemy as sa
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
-from typing import List, Optional
-from datetime import date
 
+from ..core.cache import get_cache
 from ..core.database import get_db
 from ..models.event import Event
-from ..models.schemas import Event as EventSchema, EventCreate, EventUpdate, EventResponse
+from ..models.schemas import Event as EventSchema
+from ..models.schemas import (
+    EventCreate,
+    EventResponse,
+    EventUpdate,
+)
 
 router = APIRouter(prefix="/events", tags=["events"])
 
@@ -18,44 +27,64 @@ def get_events(
     location: Optional[str] = Query(None),
     date_from: Optional[date] = Query(None),
     date_to: Optional[date] = Query(None),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    cache=Depends(get_cache),
 ):
     """Get all events with optional filtering and pagination."""
+    cache_key = json.dumps(
+        {
+            "skip": skip,
+            "limit": limit,
+            "search": search,
+            "location": location,
+            "date_from": str(date_from) if date_from else None,
+            "date_to": str(date_to) if date_to else None,
+        },
+        sort_keys=True,
+    )
+
+    cached = cache.get(cache_key)
+    if cached:
+        return EventResponse.model_validate_json(cached)
+
     query = db.query(Event)
-    
+
     # Apply filters
     if search:
         query = query.filter(
-            Event.name.ilike(f"%{search}%") | 
-            Event.description.ilike(f"%{search}%")
+            Event.search_vector.op("@@")(sa.func.plainto_tsquery("simple", search))
         )
-    
+
     if location:
         query = query.filter(Event.location.ilike(f"%{location}%"))
-    
+
     if date_from:
         query = query.filter(Event.date >= date_from)
-    
+
     if date_to:
         query = query.filter(Event.date <= date_to)
-    
+
     # Get total count
     total = query.count()
-    
+
     # Apply pagination and ordering
-    events = query.order_by(Event.date.asc(), Event.time.asc()).offset(skip).limit(limit).all()
-    
+    events = (
+        query.order_by(Event.date.asc(), Event.time.asc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
     # Calculate pagination info
     pages = (total + limit - 1) // limit if total > 0 else 0
     page = (skip // limit) + 1 if limit > 0 else 1
-    
-    return EventResponse(
-        events=events,
-        total=total,
-        page=page,
-        size=len(events),
-        pages=pages
+
+    response = EventResponse(
+        events=events, total=total, page=page, size=len(events), pages=pages
     )
+
+    cache.setex(cache_key, 300, response.model_dump_json())
+    return response
 
 
 @router.get("/{event_id}", response_model=EventSchema)
@@ -83,12 +112,12 @@ def update_event(event_id: int, event: EventUpdate, db: Session = Depends(get_db
     db_event = db.query(Event).filter(Event.id == event_id).first()
     if not db_event:
         raise HTTPException(status_code=404, detail="Event not found")
-    
+
     # Update only provided fields
     update_data = event.model_dump(exclude_unset=True)
     for field, value in update_data.items():
         setattr(db_event, field, value)
-    
+
     db.commit()
     db.refresh(db_event)
     return db_event
@@ -100,7 +129,7 @@ def delete_event(event_id: int, db: Session = Depends(get_db)):
     db_event = db.query(Event).filter(Event.id == event_id).first()
     if not db_event:
         raise HTTPException(status_code=404, detail="Event not found")
-    
+
     db.delete(db_event)
     db.commit()
     return {"message": "Event deleted successfully"}

--- a/database/init.sql
+++ b/database/init.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS events (
     price VARCHAR(50),
     image VARCHAR(500),
     link VARCHAR(500),
+    search_vector tsvector,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -19,6 +20,10 @@ CREATE TABLE IF NOT EXISTS events (
 CREATE INDEX IF NOT EXISTS idx_events_date ON events(date);
 CREATE INDEX IF NOT EXISTS idx_events_location ON events(location);
 CREATE INDEX IF NOT EXISTS idx_events_name ON events(name);
+CREATE INDEX IF NOT EXISTS idx_events_search ON events USING GIN(search_vector);
+CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE
+    ON events FOR EACH ROW EXECUTE FUNCTION
+    tsvector_update_trigger(search_vector, 'pg_catalog.simple', name, description);
 
 -- Insert sample Croatian events data
 INSERT INTO events (name, time, date, location, description, price, image, link) VALUES


### PR DESCRIPTION
## Summary
- enable Redis URL in settings and introduce cache helper
- store search vector for events and create Alembic migration
- use full-text search and Redis caching in `/events` endpoint
- initialize Alembic config
- document caching, full-text search and migrations in README

## Testing
- `uv pip install -q --system pytest sqlalchemy==2.0.23 requests beautifulsoup4 pandas pydantic-settings`
- `pytest -q`
- `pytest -q backend/test_server.py`


------
https://chatgpt.com/codex/tasks/task_e_6845b9e94454832896fa43ea62ae86df