### PR TITLE
Add caching for database metrics endpoint

### DIFF
--- a/backend/app/routes/monitoring.py
+++ b/backend/app/routes/monitoring.py
@@ -63,7 +63,7 @@ async def get_database_metrics(current_user: User = Depends(get_current_superuse
     """Get detailed database metrics."""
     try:
         monitoring_service = get_monitoring_service()
-        db_metrics = await monitoring_service.collect_database_metrics()
+        db_metrics = await monitoring_service.get_cached_database_metrics()
         
         return {
             "timestamp": datetime.now().isoformat(),


### PR DESCRIPTION
## Summary
- cache database metrics in PrometheusMonitoring
- expose `get_cached_database_metrics` helper
- use cached metrics in `/monitoring/database` route

## Testing
- `make lint-backend` *(fails: Failed to spawn flake8)*
- `make test-backend` *(fails: ValidationError for Settings)*

------
https://chatgpt.com/codex/tasks/task_e_6846a332344883288026ef617031d6bb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added caching for database metrics, improving performance and reducing database load.
  - Database metrics are now refreshed at configurable intervals (default: 60 seconds) and served from cache.

- **Chores**
  - Updated the database metrics endpoint to provide cached metrics instead of querying the database on every request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->