### PR TITLE
Add env example and use env file in compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+POSTGRES_DB=kruzna_karta_hrvatska
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=your-postgres-password
+
+DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+REDIS_URL=redis://redis:6379/0
+SECRET_KEY=your-secret-key
+DEBUG=true
+FRONTEND_URL=http://localhost:3000
+
+# Scraping Configuration
+ENABLE_SCHEDULER=false
+USE_PROXY=false
+USE_PLAYWRIGHT=true
+BRIGHTDATA_USER=your-brightdata-user
+BRIGHTDATA_PASSWORD=your-brightdata-password
+
+# Frontend
+VITE_API_BASE_URL=http://localhost:8000/api
+VITE_MAPBOX_ACCESS_TOKEN=your_mapbox_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Thumbs.db
 # Environment files
 .env
 .env.*
+!.env.example
 
 # TypeScript
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -338,25 +338,28 @@ Visit http://localhost:8000/docs for interactive API documentation (Swagger UI).
 
 ## 🔐 Environment Variables
 
-### Backend (`.env`)
+Create a `.env` file at the project root by copying `.env.example` and setting the values:
+
+### `.env`
 ```env
-DATABASE_URL=postgresql://username:password@localhost:5432/kruzna_karta_hrvatska
-SECRET_KEY=your-secret-key-here
-DEBUG=True
-FRONTEND_URL=http://localhost:5173
+POSTGRES_DB=kruzna_karta_hrvatska
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=your-postgres-password
+
+DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+REDIS_URL=redis://redis:6379/0
+SECRET_KEY=your-secret-key
+DEBUG=true
+FRONTEND_URL=http://localhost:3000
 
 # Scraping Configuration
 ENABLE_SCHEDULER=false
 USE_PROXY=false
 USE_PLAYWRIGHT=true
-
-# BrightData (optional, for proxy scraping)
 BRIGHTDATA_USER=your-brightdata-user
 BRIGHTDATA_PASSWORD=your-brightdata-password
-```
 
-### Frontend (`.env`)
-```env
+# Frontend
 VITE_API_BASE_URL=http://localhost:8000/api
 VITE_MAPBOX_ACCESS_TOKEN=your_mapbox_token_here
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,9 @@ services:
   postgres:
     image: postgres:15-alpine
     container_name: diidemo-postgres
+    env_file:
+      - .env
     environment:
-      POSTGRES_DB: kruzna_karta_hrvatska
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: diidemo2024
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - postgres_data:/var/lib/postgresql/data
@@ -27,6 +26,8 @@ services:
   redis:
     image: redis:7-alpine
     container_name: diidemo-redis
+    env_file:
+      - .env
     ports:
       - "6379:6379"
     volumes:
@@ -41,16 +42,12 @@ services:
 
   # Backend API
   backend:
-    build: 
+    build:
       context: ./backend
       dockerfile: Dockerfile
     container_name: diidemo-backend
-    environment:
-      - DATABASE_URL=postgresql://postgres:diidemo2024@postgres:5432/kruzna_karta_hrvatska
-      - REDIS_URL=redis://redis:6379/0
-      - SECRET_KEY=diidemo-secret-key-2024
-      - DEBUG=false
-      - FRONTEND_URL=http://localhost:3000
+    env_file:
+      - .env
     ports:
       - "8000:8000"
     depends_on:
@@ -74,13 +71,12 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     container_name: diidemo-frontend
+    env_file:
+      - .env
     ports:
       - "3000:80"
     depends_on:
       - backend
-    environment:
-      - VITE_API_BASE_URL=http://localhost:8000/api
-      - VITE_MAPBOX_ACCESS_TOKEN=pk.demo-token
     networks:
       - diidemo-network
 


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders for app secrets and DB credentials
- reference `.env` from docker-compose services
- document required environment variables in README
- allow `.env.example` in version control

## Testing
- `npm run test` *(fails: ValidationError due to missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_6846a4856fe48328bd19fbebe722c02a