### PR TITLE
Async Entrio scraping

### DIFF
--- a/backend/app/scraping/entrio_scraper.py
+++ b/backend/app/scraping/entrio_scraper.py
@@ -11,7 +11,7 @@ import re
 from datetime import date, datetime
 from typing import List, Dict, Optional, Tuple
 from urllib.parse import urljoin, urlparse, parse_qs
-import requests
+import httpx
 from bs4 import BeautifulSoup, Tag
 import pandas as pd
 from sqlalchemy.orm import Session
@@ -42,122 +42,144 @@ HEADERS = {
 
 class EventDataTransformer:
     """Transform scraped event data to database format."""
-    
+
     @staticmethod
     def parse_date(date_str: str) -> Optional[date]:
         """Parse various date formats into Python date object."""
         if not date_str:
             return None
-        
+
         # Common date patterns
         patterns = [
-            r'(\d{1,2})\.(\d{1,2})\.(\d{4})',  # DD.MM.YYYY
-            r'(\d{4})-(\d{1,2})-(\d{1,2})',   # YYYY-MM-DD
-            r'(\d{1,2})/(\d{1,2})/(\d{4})',   # DD/MM/YYYY
-            r'(\d{1,2})\s+(\w+)\s+(\d{4})',   # DD Month YYYY
+            r"(\d{1,2})\.(\d{1,2})\.(\d{4})",  # DD.MM.YYYY
+            r"(\d{4})-(\d{1,2})-(\d{1,2})",  # YYYY-MM-DD
+            r"(\d{1,2})/(\d{1,2})/(\d{4})",  # DD/MM/YYYY
+            r"(\d{1,2})\s+(\w+)\s+(\d{4})",  # DD Month YYYY
         ]
-        
+
         for pattern in patterns:
             match = re.search(pattern, date_str)
             if match:
                 try:
-                    if '.' in pattern or '/' in pattern:
+                    if "." in pattern or "/" in pattern:
                         day, month, year = match.groups()
                         return date(int(year), int(month), int(day))
-                    elif '-' in pattern:
+                    elif "-" in pattern:
                         year, month, day = match.groups()
                         return date(int(year), int(month), int(day))
                     else:  # Month name format
                         day, month_name, year = match.groups()
                         # Croatian month names mapping
                         months = {
-                            'siječnja': 1, 'veljače': 2, 'ožujka': 3, 'travnja': 4,
-                            'svibnja': 5, 'lipnja': 6, 'srpnja': 7, 'kolovoza': 8,
-                            'rujna': 9, 'listopada': 10, 'studenoga': 11, 'prosinca': 12,
-                            'januar': 1, 'februar': 2, 'mart': 3, 'april': 4,
-                            'maj': 5, 'jun': 6, 'jul': 7, 'avgust': 8,
-                            'septembar': 9, 'oktobar': 10, 'novembar': 11, 'decembar': 12
+                            "siječnja": 1,
+                            "veljače": 2,
+                            "ožujka": 3,
+                            "travnja": 4,
+                            "svibnja": 5,
+                            "lipnja": 6,
+                            "srpnja": 7,
+                            "kolovoza": 8,
+                            "rujna": 9,
+                            "listopada": 10,
+                            "studenoga": 11,
+                            "prosinca": 12,
+                            "januar": 1,
+                            "februar": 2,
+                            "mart": 3,
+                            "april": 4,
+                            "maj": 5,
+                            "jun": 6,
+                            "jul": 7,
+                            "avgust": 8,
+                            "septembar": 9,
+                            "oktobar": 10,
+                            "novembar": 11,
+                            "decembar": 12,
                         }
                         month_num = months.get(month_name.lower(), 1)
                         return date(int(year), month_num, int(day))
                 except (ValueError, TypeError):
                     continue
-        
+
         # Fallback: try to extract at least year
-        year_match = re.search(r'(\d{4})', date_str)
+        year_match = re.search(r"(\d{4})", date_str)
         if year_match:
             try:
                 return date(int(year_match.group(1)), 1, 1)
             except ValueError:
                 pass
-        
+
         return None
-    
+
     @staticmethod
     def parse_time(time_str: str) -> str:
         """Parse time string and return in HH:MM format."""
         if not time_str:
             return "20:00"  # Default time
-        
+
         # Look for time patterns
-        time_match = re.search(r'(\d{1,2}):(\d{2})', time_str)
+        time_match = re.search(r"(\d{1,2}):(\d{2})", time_str)
         if time_match:
             hour, minute = time_match.groups()
             return f"{int(hour):02d}:{minute}"
-        
+
         # Look for hour only
-        hour_match = re.search(r'(\d{1,2})h', time_str)
+        hour_match = re.search(r"(\d{1,2})h", time_str)
         if hour_match:
             hour = hour_match.group(1)
             return f"{int(hour):02d}:00"
-        
+
         return "20:00"  # Default time
-    
+
     @staticmethod
     def clean_text(text: str) -> str:
         """Clean and normalize text."""
         if not text:
             return ""
-        return ' '.join(text.strip().split())
-    
+        return " ".join(text.strip().split())
+
     @staticmethod
     def transform_to_event_create(scraped_data: Dict) -> Optional[EventCreate]:
         """Transform scraped data to EventCreate schema."""
         try:
             # Extract and clean basic fields
-            name = EventDataTransformer.clean_text(scraped_data.get('title', ''))
-            location = EventDataTransformer.clean_text(scraped_data.get('venue', '') or scraped_data.get('location', ''))
-            description = EventDataTransformer.clean_text(scraped_data.get('description', ''))
-            price = EventDataTransformer.clean_text(scraped_data.get('price', ''))
-            
+            name = EventDataTransformer.clean_text(scraped_data.get("title", ""))
+            location = EventDataTransformer.clean_text(
+                scraped_data.get("venue", "") or scraped_data.get("location", "")
+            )
+            description = EventDataTransformer.clean_text(
+                scraped_data.get("description", "")
+            )
+            price = EventDataTransformer.clean_text(scraped_data.get("price", ""))
+
             # Parse date
-            date_str = scraped_data.get('date', '')
+            date_str = scraped_data.get("date", "")
             parsed_date = EventDataTransformer.parse_date(date_str)
             if not parsed_date:
                 # Skip events without valid dates
                 return None
-            
+
             # Parse time
-            time_str = scraped_data.get('time', '') or scraped_data.get('date', '')
+            time_str = scraped_data.get("time", "") or scraped_data.get("date", "")
             parsed_time = EventDataTransformer.parse_time(time_str)
-            
+
             # Handle image URL
-            image_url = scraped_data.get('image_url', '')
-            if image_url and not image_url.startswith('http'):
+            image_url = scraped_data.get("image_url", "")
+            if image_url and not image_url.startswith("http"):
                 image_url = urljoin("https://entrio.hr", image_url)
-            
+
             # Handle event link
-            link = scraped_data.get('link', '')
-            if link and not link.startswith('http'):
+            link = scraped_data.get("link", "")
+            if link and not link.startswith("http"):
                 link = urljoin("https://entrio.hr", link)
-            
+
             # Validate required fields
             if not name or len(name) < 3:
                 return None
-            
+
             if not location:
                 location = "Zagreb, Croatia"  # Default location
-            
+
             return EventCreate(
                 name=name,
                 time=parsed_time,
@@ -166,147 +188,176 @@ class EventDataTransformer:
                 description=description or f"Event: {name}",
                 price=price or "Contact organizer",
                 image=image_url,
-                link=link
+                link=link,
             )
-        
+
         except Exception as e:
             print(f"Error transforming event data: {e}")
             return None
 
 
 class EntrioRequestsScraper:
-    """Scraper using requests and BeautifulSoup."""
-    
+    """Scraper using httpx and BeautifulSoup."""
+
     def __init__(self):
-        self.session = requests.Session()
-    
-    def fetch(self, url: str) -> requests.Response:
+        pass
+
+    async def fetch(self, url: str) -> httpx.Response:
         """Fetch URL with proxy support."""
         try:
-            if USE_SB and USE_PROXY:
-                params = {"url": url}
-                resp = self.session.get(
-                    SCRAPING_BROWSER_EP,
-                    params=params,
-                    headers=HEADERS,
-                    auth=(USER, PASSWORD),
-                    timeout=30,
-                    verify=False,
-                )
-            elif USE_PROXY:
-                resp = self.session.get(
-                    url, 
-                    headers=HEADERS, 
-                    proxies={"http": PROXY, "https": PROXY}, 
-                    timeout=30, 
-                    verify=False
-                )
-            else:
-                resp = self.session.get(url, headers=HEADERS, timeout=30)
+            async with httpx.AsyncClient() as client:
+                if USE_SB and USE_PROXY:
+                    params = {"url": url}
+                    resp = await client.get(
+                        SCRAPING_BROWSER_EP,
+                        params=params,
+                        headers=HEADERS,
+                        auth=(USER, PASSWORD),
+                        timeout=30,
+                        verify=False,
+                    )
+                elif USE_PROXY:
+                    resp = await client.get(
+                        url,
+                        headers=HEADERS,
+                        proxies={"http://": PROXY, "https://": PROXY},
+                        timeout=30,
+                        verify=False,
+                    )
+                else:
+                    resp = await client.get(url, headers=HEADERS, timeout=30)
             resp.raise_for_status()
             return resp
-        except requests.exceptions.RequestException as e:
+        except httpx.HTTPError as e:
             print(f"[ERROR] Request failed for {url}: {e}")
             raise
-    
+
     def parse_event_from_element(self, event_element: Tag) -> Dict:
         """Extract event details from a single event element."""
         event_data = {}
-        
+
         try:
             # Extract event link
             link_patterns = [
-                'a.poster-image', 'a[class*="event"]', 'a[href*="/event/"]',
-                'a[href*="/dogadaj/"]', 'a'
+                "a.poster-image",
+                'a[class*="event"]',
+                'a[href*="/event/"]',
+                'a[href*="/dogadaj/"]',
+                "a",
             ]
-            
+
             for pattern in link_patterns:
                 link_element = event_element.select_one(pattern)
                 if link_element and isinstance(link_element, Tag):
-                    href = link_element.get('href')
+                    href = link_element.get("href")
                     if href and isinstance(href, str):
-                        event_data['link'] = urljoin("https://entrio.hr", href) if href.startswith('/') else href
+                        event_data["link"] = (
+                            urljoin("https://entrio.hr", href)
+                            if href.startswith("/")
+                            else href
+                        )
                         break
-            
+
             # Extract image URL
-            img_patterns = ['img[src]', 'img[data-src]', '[style*="background-image"]']
+            img_patterns = ["img[src]", "img[data-src]", '[style*="background-image"]']
             for pattern in img_patterns:
                 img_element = event_element.select_one(pattern)
                 if img_element and isinstance(img_element, Tag):
-                    src = img_element.get('src') or img_element.get('data-src')
+                    src = img_element.get("src") or img_element.get("data-src")
                     if src and isinstance(src, str):
-                        event_data['image_url'] = src
+                        event_data["image_url"] = src
                         break
-            
+
             # Extract title
             title_patterns = [
-                '.event-title', '.title', 'h1, h2, h3, h4, h5, h6',
-                '[class*="title"]', '[class*="name"]'
+                ".event-title",
+                ".title",
+                "h1, h2, h3, h4, h5, h6",
+                '[class*="title"]',
+                '[class*="name"]',
             ]
             for pattern in title_patterns:
                 title_element = event_element.select_one(pattern)
                 if title_element:
                     title_text = title_element.get_text(strip=True)
                     if title_text and len(title_text) > 2:
-                        event_data['title'] = title_text
+                        event_data["title"] = title_text
                         break
-            
+
             # Extract date
             date_patterns = [
-                '.date-overlay', '.date', '.event-date', '[class*="date"]', 'time'
+                ".date-overlay",
+                ".date",
+                ".event-date",
+                '[class*="date"]',
+                "time",
             ]
             for pattern in date_patterns:
                 date_element = event_element.select_one(pattern)
                 if date_element:
                     date_text = date_element.get_text(strip=True)
                     if date_text:
-                        event_data['date'] = date_text
+                        event_data["date"] = date_text
                         break
-            
+
             # Extract venue/location
             venue_patterns = [
-                '.event-venue', '.venue', '.location', '[class*="venue"]', '[class*="location"]'
+                ".event-venue",
+                ".venue",
+                ".location",
+                '[class*="venue"]',
+                '[class*="location"]',
             ]
             for pattern in venue_patterns:
                 venue_element = event_element.select_one(pattern)
                 if venue_element:
                     venue_text = venue_element.get_text(strip=True)
                     if venue_text:
-                        event_data['venue'] = venue_text
+                        event_data["venue"] = venue_text
                         break
-            
+
             # Extract price
             price_patterns = [
-                '.price', '.event-price', '[class*="price"]', '[class*="cost"]'
+                ".price",
+                ".event-price",
+                '[class*="price"]',
+                '[class*="cost"]',
             ]
             for pattern in price_patterns:
                 price_element = event_element.select_one(pattern)
                 if price_element:
                     price_text = price_element.get_text(strip=True)
                     if price_text:
-                        event_data['price'] = price_text
+                        event_data["price"] = price_text
                         break
-        
+
         except Exception as e:
             print(f"Error parsing event element: {e}")
-        
+
         return event_data
-    
-    def scrape_events_page(self, url: str) -> Tuple[List[Dict], Optional[str]]:
+
+    async def scrape_events_page(self, url: str) -> Tuple[List[Dict], Optional[str]]:
         """Scrape events from a single page."""
         print(f"→ Fetching {url}")
-        resp = self.fetch(url)
-        soup = BeautifulSoup(resp.text, 'html.parser')
-        
+        resp = await self.fetch(url)
+        soup = BeautifulSoup(resp.text, "html.parser")
+
         events = []
-        
+
         # Event selectors
         event_selectors = [
-            '.poster-image', '.event-poster', '.event-item', '.event-card',
-            '.event-listing', '[class*="event"]', 'article[class*="event"]',
-            'div[class*="card"]', 'a[href*="/event/"]', 'a[href*="/dogadaj/"]'
+            ".poster-image",
+            ".event-poster",
+            ".event-item",
+            ".event-card",
+            ".event-listing",
+            '[class*="event"]',
+            'article[class*="event"]',
+            'div[class*="card"]',
+            'a[href*="/event/"]',
+            'a[href*="/dogadaj/"]',
         ]
-        
+
         event_elements = []
         for selector in event_selectors:
             elements = soup.select(selector)
@@ -314,87 +365,109 @@ class EntrioRequestsScraper:
                 print(f"Found {len(elements)} events using selector: {selector}")
                 event_elements = elements
                 break
-        
+
         # Parse events
         for event_element in event_elements:
             if isinstance(event_element, Tag):
                 event_data = self.parse_event_from_element(event_element)
                 if event_data and len(event_data) > 1:
                     events.append(event_data)
-        
+
         # Find next page
         next_page_url = None
         pagination_selectors = [
-            'a[class*="next"]', 'a[aria-label*="Next"]', '.pagination a:last-child', 'a[rel="next"]'
+            'a[class*="next"]',
+            'a[aria-label*="Next"]',
+            ".pagination a:last-child",
+            'a[rel="next"]',
         ]
-        
+
         for selector in pagination_selectors:
             next_link = soup.select_one(selector)
             if next_link and isinstance(next_link, Tag):
-                href = next_link.get('href')
+                href = next_link.get("href")
                 if href and isinstance(href, str):
                     next_page_url = urljoin(url, href)
                     break
-        
+
         print(f"Extracted {len(events)} events from page")
         return events, next_page_url
-    
-    def scrape_all_events(self, start_url: str = "https://entrio.hr/events", max_pages: int = 5) -> List[Dict]:
+
+    async def scrape_all_events(
+        self, start_url: str = "https://entrio.hr/events", max_pages: int = 5
+    ) -> List[Dict]:
         """Scrape all events with pagination."""
-        all_events = []
-        current_url = start_url
-        page_count = 0
-        
-        while current_url and page_count < max_pages:
-            try:
-                events, next_url = self.scrape_events_page(current_url)
+        all_events: List[Dict] = []
+        to_visit: List[str] = [start_url]
+        visited = 0
+
+        concurrency = 3
+        semaphore = asyncio.Semaphore(concurrency)
+
+        async def worker(url: str) -> Tuple[List[Dict], Optional[str]]:
+            async with semaphore:
+                result = await self.scrape_events_page(url)
+                await asyncio.sleep(1)
+                return result
+
+        while to_visit and visited < max_pages:
+            batch = []
+            while (
+                to_visit
+                and len(batch) < concurrency
+                and visited + len(batch) < max_pages
+            ):
+                url = to_visit.pop(0)
+                batch.append(worker(url))
+
+            results = await asyncio.gather(*batch)
+
+            for events, next_url in results:
+                visited += 1
                 all_events.extend(events)
-                
-                page_count += 1
-                print(f"Page {page_count}: Found {len(events)} events (Total: {len(all_events)})")
-                
-                if not events:
-                    break
-                
-                current_url = next_url
-                time.sleep(1)  # Be respectful
-                
-            except Exception as e:
-                print(f"Failed to scrape page {current_url}: {e}")
-                break
-        
+                print(
+                    f"Page {visited}: Found {len(events)} events (Total: {len(all_events)})"
+                )
+                if next_url and visited < max_pages:
+                    to_visit.append(next_url)
+
         return all_events
 
 
 class EntrioPlaywrightScraper:
     """Scraper using Playwright for JavaScript-heavy pages."""
-    
-    async def scrape_with_playwright(self, start_url: str = "https://entrio.hr/events", max_pages: int = 3) -> List[Dict]:
+
+    async def scrape_with_playwright(
+        self, start_url: str = "https://entrio.hr/events", max_pages: int = 3
+    ) -> List[Dict]:
         """Scrape events using Playwright."""
         from playwright.async_api import async_playwright
-        
+
         all_events = []
         current_url = start_url
         page_count = 0
-        
+
         async with async_playwright() as p:
             if USE_PROXY:
                 browser = await p.chromium.connect_over_cdp(BRD_WSS)
             else:
                 browser = await p.chromium.launch()
-            
+
             page = await browser.new_page()
-            
+
             while current_url and page_count < max_pages:
                 try:
                     print(f"→ Fetching {current_url}")
-                    await page.goto(current_url, wait_until="domcontentloaded", timeout=90000)
-                    
+                    await page.goto(
+                        current_url, wait_until="domcontentloaded", timeout=90000
+                    )
+
                     # Wait for content to load
                     await page.wait_for_timeout(3000)
-                    
+
                     # Extract events using JavaScript evaluation
-                    events_data = await page.evaluate("""
+                    events_data = await page.evaluate(
+                        """
                         () => {
                             const events = [];
                             const eventSelectors = [
@@ -459,103 +532,117 @@ class EntrioPlaywrightScraper:
                             
                             return events;
                         }
-                    """)
-                    
+                    """
+                    )
+
                     all_events.extend(events_data)
                     page_count += 1
-                    print(f"Page {page_count}: Found {len(events_data)} events (Total: {len(all_events)})")
-                    
+                    print(
+                        f"Page {page_count}: Found {len(events_data)} events (Total: {len(all_events)})"
+                    )
+
                     if not events_data:
                         break
-                    
+
                     # Try to find next page
-                    next_link = await page.query_selector('a[class*="next"], a[aria-label*="Next"]')
+                    next_link = await page.query_selector(
+                        'a[class*="next"], a[aria-label*="Next"]'
+                    )
                     if next_link:
-                        current_url = await next_link.get_attribute('href')
+                        current_url = await next_link.get_attribute("href")
                         if current_url:
                             current_url = urljoin(start_url, current_url)
                         else:
                             break
                     else:
                         break
-                    
+
                     await asyncio.sleep(2)
-                
+
                 except Exception as e:
                     print(f"Failed to scrape page {current_url}: {e}")
                     break
-            
+
             await browser.close()
-        
+
         return all_events
 
 
 class EntrioScraper:
     """Main scraper class that combines both approaches."""
-    
+
     def __init__(self):
         self.requests_scraper = EntrioRequestsScraper()
         self.playwright_scraper = EntrioPlaywrightScraper()
         self.transformer = EventDataTransformer()
-    
-    async def scrape_events(self, max_pages: int = 5, use_playwright: bool = None) -> List[EventCreate]:
+
+    async def scrape_events(
+        self, max_pages: int = 5, use_playwright: bool = None
+    ) -> List[EventCreate]:
         """Scrape events and return as EventCreate objects."""
         if use_playwright is None:
             use_playwright = USE_PLAYWRIGHT
-        
+
         print(f"Starting Entrio.hr scraper (Playwright: {use_playwright})")
-        
+
         # Scrape raw data
         if use_playwright:
-            raw_events = await self.playwright_scraper.scrape_with_playwright(max_pages=max_pages)
+            raw_events = await self.playwright_scraper.scrape_with_playwright(
+                max_pages=max_pages
+            )
         else:
-            raw_events = self.requests_scraper.scrape_all_events(max_pages=max_pages)
-        
+            raw_events = await self.requests_scraper.scrape_all_events(
+                max_pages=max_pages
+            )
+
         print(f"Scraped {len(raw_events)} raw events")
-        
+
         # Transform to EventCreate objects
         events = []
         for raw_event in raw_events:
             event = self.transformer.transform_to_event_create(raw_event)
             if event:
                 events.append(event)
-        
+
         print(f"Transformed {len(events)} valid events")
         return events
-    
+
     def save_events_to_database(self, events: List[EventCreate]) -> int:
         """Save events to database and return count of saved events."""
         if not events:
             return 0
-        
+
         db = SessionLocal()
         saved_count = 0
-        
+
         try:
             for event_data in events:
                 # Check if event already exists (by name and date)
-                existing = db.query(Event).filter(
-                    Event.name == event_data.name,
-                    Event.date == event_data.date
-                ).first()
-                
+                existing = (
+                    db.query(Event)
+                    .filter(
+                        Event.name == event_data.name, Event.date == event_data.date
+                    )
+                    .first()
+                )
+
                 if not existing:
                     db_event = Event(**event_data.model_dump())
                     db.add(db_event)
                     saved_count += 1
                 else:
                     print(f"Event already exists: {event_data.name}")
-            
+
             db.commit()
             print(f"Saved {saved_count} new events to database")
-            
+
         except Exception as e:
             print(f"Error saving events to database: {e}")
             db.rollback()
             raise
         finally:
             db.close()
-        
+
         return saved_count
 
 
@@ -563,20 +650,17 @@ class EntrioScraper:
 async def scrape_entrio_events(max_pages: int = 5) -> Dict:
     """Scrape Entrio events and save to database."""
     scraper = EntrioScraper()
-    
+
     try:
         events = await scraper.scrape_events(max_pages=max_pages)
         saved_count = scraper.save_events_to_database(events)
-        
+
         return {
             "status": "success",
             "scraped_events": len(events),
             "saved_events": saved_count,
-            "message": f"Successfully scraped {len(events)} events, saved {saved_count} new events"
+            "message": f"Successfully scraped {len(events)} events, saved {saved_count} new events",
         }
-    
+
     except Exception as e:
-        return {
-            "status": "error",
-            "message": f"Scraping failed: {str(e)}"
-        }
+        return {"status": "error", "message": f"Scraping failed: {str(e)}"}

--- a/backend/tests/test_entrio_async.py
+++ b/backend/tests/test_entrio_async.py
@@ -1,0 +1,85 @@
+import os
+import sys
+
+import pytest
+import httpx
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("SECRET_KEY", "test")
+from app.scraping.entrio_scraper import EntrioRequestsScraper
+
+
+@pytest.mark.asyncio
+async def test_scrape_events_page_async(monkeypatch):
+    html = """
+    <html><body>
+        <div class="event-item">
+            <a href="/event/1" class="event-link">
+                <img src="img1.jpg" />
+                <div class="event-title">Test Event 1</div>
+            </a>
+            <div class="event-date">01.01.2025</div>
+            <div class="event-venue">Zagreb</div>
+            <div class="price">100kn</div>
+        </div>
+        <a class="next" href="page2.html">Next</a>
+    </body></html>
+    """
+
+    scraper = EntrioRequestsScraper()
+
+    async def fake_fetch(url: str):
+        return httpx.Response(status_code=200, text=html)
+
+    monkeypatch.setattr(scraper, "fetch", fake_fetch)
+
+    events, next_url = await scraper.scrape_events_page("http://test/page1")
+
+    assert next_url.endswith("page2.html")
+    assert len(events) == 1
+    assert events[0]["title"] == "Test Event 1"
+
+
+@pytest.mark.asyncio
+async def test_scrape_all_events_async(monkeypatch):
+    page1 = """
+    <html><body>
+        <div class="event-item">
+            <a href="/event/1" class="event-link">
+                <div class="event-title">Event 1</div>
+            </a>
+            <div class="event-date">01.01.2025</div>
+        </div>
+        <a class="next" href="page2.html">Next</a>
+    </body></html>
+    """
+
+    page2 = """
+    <html><body>
+        <div class="event-item">
+            <a href="/event/2" class="event-link">
+                <div class="event-title">Event 2</div>
+            </a>
+            <div class="event-date">02.01.2025</div>
+        </div>
+    </body></html>
+    """
+
+    responses = {
+        "http://test/page1": page1,
+        "http://test/page2.html": page2,
+    }
+
+    scraper = EntrioRequestsScraper()
+
+    async def fake_fetch(url: str):
+        return httpx.Response(status_code=200, text=responses[url])
+
+    monkeypatch.setattr(scraper, "fetch", fake_fetch)
+
+    events = await scraper.scrape_all_events(start_url="http://test/page1", max_pages=2)
+
+    titles = [e["title"] for e in events]
+    assert titles == ["Event 1", "Event 2"]
+    assert len(events) == 2


### PR DESCRIPTION
## Summary
- refactor Entrio requests scraper to use `httpx.AsyncClient`
- make `scrape_events_page` and `scrape_all_events` async
- fetch multiple pages concurrently with `asyncio.gather`
- adjust main scraping API to await async requests scraping
- add async unit tests for Entrio scraper

## Testing
- `pytest -q tests/test_entrio_async.py`

------
https://chatgpt.com/codex/tasks/task_e_6846a48d27ec83289975f67a1b8e5414