### PR TITLE
Remove direct console logging

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -24,6 +24,7 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
       "@typescript-eslint/no-unused-vars": "off",
+      "no-console": ["error", { allow: ["warn"] }],
     },
   }
 );

--- a/frontend/src/components/EventMap.tsx
+++ b/frontend/src/components/EventMap.tsx
@@ -33,6 +33,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import type { DateRange } from "react-day-picker";
 import { useEvents } from "@/hooks/useEvents";
 import { Event } from "@/lib/api";
+import { debugError } from "@/lib/debug";
 import {
   getCoordinatesForLocation,
   addCoordinateJitter,
@@ -92,7 +93,7 @@ const EventMap = () => {
 
   // API filters based on current selections
   const apiFilters = useMemo(() => {
-    const filters: any = {};
+    const filters: Record<string, string> = {};
 
     if (searchTerm) {
       filters.search = searchTerm;
@@ -293,7 +294,7 @@ const EventMap = () => {
 
     const mapboxToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN;
     if (!mapboxToken) {
-      console.error("Mapbox access token is required");
+      debugError("Mapbox access token is required");
       return;
     }
 

--- a/frontend/src/components/EventMapDemo.tsx
+++ b/frontend/src/components/EventMapDemo.tsx
@@ -39,7 +39,7 @@ const EventMapDemo = () => {
 
   // API filters based on current selections
   const apiFilters = useMemo(() => {
-    const filters: any = {};
+    const filters: Record<string, string> = {};
     if (searchTerm) {
       filters.search = searchTerm;
     }

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -16,6 +16,7 @@ import { Separator } from "./ui/separator";
 import { FcGoogle } from "react-icons/fc";
 import { toast } from "../hooks/use-toast";
 import { login, signup, googleLogin } from "../lib/auth";
+import { debugError } from "../lib/debug";
 
 interface LoginFormProps {
   mode: "login" | "signup";
@@ -65,7 +66,7 @@ const LoginForm = ({
       }
       onLoginSuccess();
     } catch (error: unknown) {
-      console.error("Authentication error:", error);
+      debugError("Authentication error:", error);
       const errorMessage =
         error instanceof Error
           ? error.message
@@ -90,7 +91,7 @@ const LoginForm = ({
       });
       onLoginSuccess();
     } catch (error: unknown) {
-      console.error("Google authentication error:", error);
+      debugError("Google authentication error:", error);
       const errorMessage =
         error instanceof Error
           ? error.message

--- a/frontend/src/hooks/useEvents.ts
+++ b/frontend/src/hooks/useEvents.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { eventsApi, Event, EventFilters } from "../lib/api";
+import { debugError } from "../lib/debug";
 
 export interface UseEventsOptions {
   filters?: EventFilters;
@@ -57,7 +58,7 @@ export const useEvents = (options: UseEventsOptions = {}): UseEventsReturn => {
       );
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to fetch events");
-      console.error("Error fetching events:", err);
+      debugError("Error fetching events:", err);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/lib/debug.ts
+++ b/frontend/src/lib/debug.ts
@@ -1,0 +1,14 @@
+export function debugLog(...args: unknown[]) {
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log(...args);
+  }
+}
+
+export function debugError(...args: unknown[]) {
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.error(...args);
+  }
+}
+

--- a/frontend/src/lib/geocoding.ts
+++ b/frontend/src/lib/geocoding.ts
@@ -1,4 +1,5 @@
 // Geocoding utilities for converting location names to coordinates
+import { debugError } from "./debug";
 
 export interface Coordinates {
   lat: number;
@@ -193,7 +194,7 @@ export async function geocodeLocation(
 
     return null;
   } catch (error) {
-    console.error("Geocoding error:", error);
+    debugError("Geocoding error:", error);
     return null;
   }
 }

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import { debugLog, debugError } from "@/lib/debug";
 
 interface ScrapeResponse {
   status: string;
@@ -27,7 +28,7 @@ interface ScrapeResponse {
   scraped_events?: number;
   saved_events?: number;
   task_id?: string;
-  details?: Record<string, any>;
+  details?: Record<string, ScrapeResponse>;
 }
 
 const Admin = () => {
@@ -138,10 +139,10 @@ const Admin = () => {
     try {
       const response = await fetch(`${apiBase}/scraping/status`);
       const status = await response.json();
-      console.log("Scraping Status:", status);
+      debugLog("Scraping Status:", status);
       alert(`Scraping system is ${status.status}. Check console for details.`);
     } catch (error) {
-      console.error("Failed to check status:", error);
+      debugError("Failed to check status:", error);
       alert("Failed to check scraping status");
     }
   };
@@ -464,7 +465,7 @@ const Admin = () => {
                         {results["all"].details && (
                           <div className="mt-2 space-y-1 text-xs">
                             {Object.entries(results["all"].details).map(
-                              ([site, result]: [string, any]) => (
+                              ([site, result]: [string, ScrapeResponse]) => (
                                 <div key={site}>
                                   <strong>{site}:</strong> {result.message}
                                 </div>

--- a/frontend/src/pages/CreateEvent.tsx
+++ b/frontend/src/pages/CreateEvent.tsx
@@ -12,6 +12,7 @@ import { Plus, X, Save, Clock, MapPin, Calendar, Tag, DollarSign } from 'lucide-
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import PageTransition from '../components/PageTransition';
+import { debugError } from '../lib/debug';
 
 interface TicketType {
   name: string;
@@ -82,7 +83,7 @@ const CreateEvent = () => {
       const data = await response.json();
       setCategories(data.categories || []);
     } catch (error) {
-      console.error('Error fetching categories:', error);
+      debugError('Error fetching categories:', error);
     }
   };
 
@@ -93,7 +94,7 @@ const CreateEvent = () => {
       const data = await response.json();
       setVenues(data.venues || []);
     } catch (error) {
-      console.error('Error fetching venues:', error);
+      debugError('Error fetching venues:', error);
     }
   };
 
@@ -217,7 +218,7 @@ const CreateEvent = () => {
         }
       }
     } catch (error) {
-      console.error('Error creating event:', error);
+      debugError('Error creating event:', error);
       setErrors({ form: 'Network error. Please check your connection and try again.' });
     } finally {
       setLoading(false);

--- a/frontend/src/pages/OrganizerDashboard.tsx
+++ b/frontend/src/pages/OrganizerDashboard.tsx
@@ -6,6 +6,7 @@ import { Badge } from '../components/ui/badge';
 import { Alert, AlertDescription } from '../components/ui/alert';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
+import { debugError } from '../lib/debug';
 import { 
   ChartContainer,
   ChartTooltip,
@@ -251,7 +252,7 @@ const OrganizerDashboard = () => {
       }
 
     } catch (error) {
-      console.error('Error fetching analytics data:', error);
+      debugError('Error fetching analytics data:', error);
     } finally {
       setAnalyticsLoading(false);
     }
@@ -305,7 +306,7 @@ const OrganizerDashboard = () => {
       }
 
     } catch (error) {
-      console.error('Error fetching data:', error);
+      debugError('Error fetching data:', error);
       setError('Network error. Please check your connection.');
     } finally {
       setLoading(false);

--- a/frontend/src/pages/Venues.tsx
+++ b/frontend/src/pages/Venues.tsx
@@ -38,6 +38,7 @@ import {
   Mail,
 } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
+import { debugLog } from "@/lib/debug";
 import {
   Dialog,
   DialogContent,
@@ -249,7 +250,7 @@ const Venues = () => {
 
   const handleContactSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    console.log("Contact form submitted:", contactForm);
+    debugLog("Contact form submitted:", contactForm);
 
     toast({
       title: "Request Sent",


### PR DESCRIPTION
## Summary
- wrap runtime logs with `debugLog`/`debugError`
- disable console statements in production via helper functions
- forbid future `console` calls in eslint

## Testing
- `npm run lint`
- `npm test` *(fails: pydantic ValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_6846a48a7a5083289dfd19eda55f30bb