### PR TITLE
Add MapFilters type for map components

### DIFF
--- a/frontend/src/components/EventMap.tsx
+++ b/frontend/src/components/EventMap.tsx
@@ -32,7 +32,7 @@ import { Calendar } from "@/components/ui/calendar";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import type { DateRange } from "react-day-picker";
 import { useEvents } from "@/hooks/useEvents";
-import { Event } from "@/lib/api";
+import { Event, MapFilters } from "@/lib/api";
 import {
   getCoordinatesForLocation,
   addCoordinateJitter,
@@ -92,7 +92,7 @@ const EventMap = () => {
 
   // API filters based on current selections
   const apiFilters = useMemo(() => {
-    const filters: any = {};
+    const filters: MapFilters = {};
 
     if (searchTerm) {
       filters.search = searchTerm;
@@ -126,7 +126,7 @@ const EventMap = () => {
   ]);
 
   // Fetch events from API
-  const { events, loading, error, total, refetch } = useEvents({
+  const { events, loading, error, total, refetch } = useEvents<MapFilters>({
     filters: apiFilters,
     autoFetch: true,
   });

--- a/frontend/src/components/EventMapDemo.tsx
+++ b/frontend/src/components/EventMapDemo.tsx
@@ -15,6 +15,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useEvents } from "@/hooks/useEvents";
+import { MapFilters } from "@/lib/api";
 import { useLanguage } from "@/contexts/LanguageContext";
 
 // Event category mapping and icons
@@ -39,7 +40,7 @@ const EventMapDemo = () => {
 
   // API filters based on current selections
   const apiFilters = useMemo(() => {
-    const filters: any = {};
+    const filters: MapFilters = {};
     if (searchTerm) {
       filters.search = searchTerm;
     }
@@ -47,7 +48,7 @@ const EventMapDemo = () => {
   }, [searchTerm]);
 
   // Fetch events from API
-  const { events, loading, error, total, refetch } = useEvents({
+  const { events, loading, error, total, refetch } = useEvents<MapFilters>({
     filters: apiFilters,
     autoFetch: true,
   });

--- a/frontend/src/hooks/useEvents.ts
+++ b/frontend/src/hooks/useEvents.ts
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
 import { eventsApi, Event, EventFilters } from "../lib/api";
 
-export interface UseEventsOptions {
-  filters?: EventFilters;
+export interface UseEventsOptions<F extends EventFilters = EventFilters> {
+  filters?: F;
   autoFetch?: boolean;
 }
 
@@ -16,8 +16,10 @@ export interface UseEventsReturn {
   hasMore: boolean;
 }
 
-export const useEvents = (options: UseEventsOptions = {}): UseEventsReturn => {
-  const { filters = {}, autoFetch = true } = options;
+export const useEvents = <F extends EventFilters = EventFilters>(
+  options: UseEventsOptions<F> = {},
+): UseEventsReturn => {
+  const { filters = {} as F, autoFetch = true } = options;
 
   const [events, setEvents] = useState<Event[]>([]);
   const [loading, setLoading] = useState(false);
@@ -37,7 +39,7 @@ export const useEvents = (options: UseEventsOptions = {}): UseEventsReturn => {
       const size = 20;
 
       const response = await eventsApi.getEvents({
-        ...filters,
+        ...(filters as EventFilters),
         page: currentPage,
         size,
       });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -54,6 +54,13 @@ export interface EventFilters {
   date_to?: string;
 }
 
+export interface MapFilters {
+  search?: string;
+  location?: string;
+  date_from?: string;
+  date_to?: string;
+}
+
 class ApiError extends Error {
   constructor(
     public status: number,


### PR DESCRIPTION
## Summary
- define `MapFilters` type
- use `MapFilters` in map components
- support generic filters in `useEvents`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: validation errors during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_6846a6ac88648328ac92be621e1c8c16