### PR TITLE
Add CSS class for map markers

### DIFF
--- a/frontend/src/components/EventMap.tsx
+++ b/frontend/src/components/EventMap.tsx
@@ -337,19 +337,7 @@ const EventMap = () => {
       // Create marker element
       const el = document.createElement("div");
       el.className = "event-marker";
-      el.style.cssText = `
-        width: 40px;
-        height: 40px;
-        background-color: ${config.color};
-        border: 3px solid white;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        cursor: pointer;
-        box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-        transition: transform 0.2s;
-      `;
+      el.style.backgroundColor = config.color;
 
       // Add icon
       el.innerHTML = `

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -118,4 +118,17 @@
   .language-toggle:not(.active) {
     @apply border-transparent hover:border-medium-blue;
   }
+
+  .event-marker {
+    width: 40px;
+    height: 40px;
+    border: 3px solid white;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s;
+  }
 }


### PR DESCRIPTION
## Summary
- style event markers in CSS
- use `.event-marker` class in `EventMap` and keep inline color customization

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: ValidationError: database_url, secret_key missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846a6b068d48328ba36a05b2d20e219