### PR TITLE
Use logging instead of print statements

### DIFF
--- a/backend/app/cli/backup_cli.py
+++ b/backend/app/cli/backup_cli.py
@@ -8,9 +8,15 @@ import sys
 import os
 from pathlib import Path
 from datetime import datetime
+import logging
+
+from app.logging_config import configure_logging
 
 # Add the app directory to the path so we can import our modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+configure_logging()
+logger = logging.getLogger(__name__)
 
 from core.backup import PostgreSQLBackupService
 
@@ -25,30 +31,30 @@ def cmd_create_full_backup(args):
     try:
         backup_service = create_backup_service()
         
-        print(f"Starting full backup...")
-        print(f"Include analytics: {args.include_analytics}")
+        logger.info(f"Starting full backup...")
+        logger.info(f"Include analytics: {args.include_analytics}")
         if args.filename:
-            print(f"Custom filename: {args.filename}")
+            logger.info(f"Custom filename: {args.filename}")
         
         metadata = backup_service.create_full_backup(
             custom_filename=args.filename,
             include_analytics=args.include_analytics
         )
         
-        print(f"✓ Full backup completed successfully!")
-        print(f"  Backup ID: {metadata.backup_id}")
-        print(f"  File: {metadata.file_path}")
-        print(f"  Size: {metadata.file_size:,} bytes")
-        print(f"  Duration: {metadata.duration_seconds:.2f} seconds")
-        print(f"  Tables: {len(metadata.tables_included)}")
+        logger.info(f"✓ Full backup completed successfully!")
+        logger.info(f"  Backup ID: {metadata.backup_id}")
+        logger.info(f"  File: {metadata.file_path}")
+        logger.info(f"  Size: {metadata.file_size:,} bytes")
+        logger.info(f"  Duration: {metadata.duration_seconds:.2f} seconds")
+        logger.info(f"  Tables: {len(metadata.tables_included)}")
         
         if metadata.storage_location:
-            print(f"  S3 Location: {metadata.storage_location}")
+            logger.info(f"  S3 Location: {metadata.storage_location}")
         
         return 0
     
     except Exception as e:
-        print(f"✗ Full backup failed: {e}")
+        logger.error(f"✗ Full backup failed: {e}")
         return 1
 
 
@@ -57,20 +63,20 @@ def cmd_create_schema_backup(args):
     try:
         backup_service = create_backup_service()
         
-        print("Starting schema backup...")
+        logger.info("Starting schema backup...")
         
         metadata = backup_service.create_schema_backup()
         
-        print(f"✓ Schema backup completed successfully!")
-        print(f"  Backup ID: {metadata.backup_id}")
-        print(f"  File: {metadata.file_path}")
-        print(f"  Size: {metadata.file_size:,} bytes")
-        print(f"  Duration: {metadata.duration_seconds:.2f} seconds")
+        logger.info(f"✓ Schema backup completed successfully!")
+        logger.info(f"  Backup ID: {metadata.backup_id}")
+        logger.info(f"  File: {metadata.file_path}")
+        logger.info(f"  Size: {metadata.file_size:,} bytes")
+        logger.info(f"  Duration: {metadata.duration_seconds:.2f} seconds")
         
         return 0
     
     except Exception as e:
-        print(f"✗ Schema backup failed: {e}")
+        logger.error(f"✗ Schema backup failed: {e}")
         return 1
 
 
@@ -81,31 +87,31 @@ def cmd_list_backups(args):
         backups = backup_service.list_backups()
         
         if not backups:
-            print("No backups found.")
+            logger.info("No backups found.")
             return 0
         
-        print(f"\nFound {len(backups)} backup(s):\n")
+        logger.info(f"\nFound {len(backups)} backup(s):\n")
         
         for backup in backups:
             created_at = datetime.fromisoformat(backup['created_at'])
             size_mb = backup['file_size'] / 1024 / 1024
             
-            print(f"ID: {backup['backup_id']}")
-            print(f"  Type: {backup['backup_type']}")
-            print(f"  Created: {created_at.strftime('%Y-%m-%d %H:%M:%S')}")
-            print(f"  Size: {size_mb:.1f} MB")
-            print(f"  Status: {backup['status']}")
-            print(f"  File: {backup['file_path']}")
+            logger.info(f"ID: {backup['backup_id']}")
+            logger.info(f"  Type: {backup['backup_type']}")
+            logger.info(f"  Created: {created_at.strftime('%Y-%m-%d %H:%M:%S')}")
+            logger.info(f"  Size: {size_mb:.1f} MB")
+            logger.info(f"  Status: {backup['status']}")
+            logger.info(f"  File: {backup['file_path']}")
             
             if backup.get('storage_location'):
-                print(f"  S3: {backup['storage_location']}")
+                logger.info(f"  S3: {backup['storage_location']}")
             
-            print()
+            logger.info()
         
         return 0
     
     except Exception as e:
-        print(f"✗ Failed to list backups: {e}")
+        logger.error(f"✗ Failed to list backups: {e}")
         return 1
 
 
@@ -114,27 +120,27 @@ def cmd_verify_backup(args):
     try:
         backup_service = create_backup_service()
         
-        print(f"Verifying backup: {args.backup_path}")
+        logger.info(f"Verifying backup: {args.backup_path}")
         
         result = backup_service.verify_backup(args.backup_path)
         
         if result['status'] == 'success':
-            print("✓ Backup verification successful!")
-            print(f"  File exists: {result['file_exists']}")
-            print(f"  File size: {result['file_size']:,} bytes")
-            print(f"  PostgreSQL readable: {result['pg_readable']}")
+            logger.info("✓ Backup verification successful!")
+            logger.info(f"  File exists: {result['file_exists']}")
+            logger.info(f"  File size: {result['file_size']:,} bytes")
+            logger.info(f"  PostgreSQL readable: {result['pg_readable']}")
             
             if result['checksum_match'] is not None:
-                print(f"  Checksum match: {result['checksum_match']}")
-                print(f"  Current checksum: {result['current_checksum']}")
+                logger.info(f"  Checksum match: {result['checksum_match']}")
+                logger.info(f"  Current checksum: {result['current_checksum']}")
         else:
-            print(f"✗ Backup verification failed: {result['error']}")
+            logger.error(f"✗ Backup verification failed: {result['error']}")
             return 1
         
         return 0
     
     except Exception as e:
-        print(f"✗ Backup verification failed: {e}")
+        logger.error(f"✗ Backup verification failed: {e}")
         return 1
 
 
@@ -143,16 +149,16 @@ def cmd_restore_backup(args):
     try:
         backup_service = create_backup_service()
         
-        print(f"Restoring from backup: {args.backup_path}")
+        logger.info(f"Restoring from backup: {args.backup_path}")
         if args.target_database:
-            print(f"Target database: {args.target_database}")
-        print(f"Drop existing: {args.drop_existing}")
+            logger.info(f"Target database: {args.target_database}")
+        logger.info(f"Drop existing: {args.drop_existing}")
         
         # Confirmation prompt
         if not args.yes:
             response = input("Are you sure you want to proceed? This will modify the database. (y/N): ")
             if response.lower() != 'y':
-                print("Restore cancelled.")
+                logger.info("Restore cancelled.")
                 return 0
         
         result = backup_service.restore_from_backup(
@@ -161,14 +167,14 @@ def cmd_restore_backup(args):
             drop_existing=args.drop_existing
         )
         
-        print("✓ Database restore completed successfully!")
-        print(f"  Target database: {result['target_database']}")
-        print(f"  Duration: {result['duration_seconds']:.2f} seconds")
+        logger.info("✓ Database restore completed successfully!")
+        logger.info(f"  Target database: {result['target_database']}")
+        logger.info(f"  Duration: {result['duration_seconds']:.2f} seconds")
         
         return 0
     
     except Exception as e:
-        print(f"✗ Database restore failed: {e}")
+        logger.error(f"✗ Database restore failed: {e}")
         return 1
 
 
@@ -177,32 +183,32 @@ def cmd_cleanup_backups(args):
     try:
         backup_service = create_backup_service()
         
-        print("Cleaning up old backups...")
+        logger.info("Cleaning up old backups...")
         
         # Confirmation prompt
         if not args.yes:
             response = input(f"This will delete backups older than {backup_service.max_backup_age_days} days. Continue? (y/N): ")
             if response.lower() != 'y':
-                print("Cleanup cancelled.")
+                logger.info("Cleanup cancelled.")
                 return 0
         
         result = backup_service.cleanup_old_backups()
         
         if result['status'] == 'success':
-            print("✓ Backup cleanup completed successfully!")
-            print(f"  Files cleaned: {result['cleaned_files']}")
-            print(f"  Space freed: {result['size_freed_bytes']:,} bytes")
+            logger.info("✓ Backup cleanup completed successfully!")
+            logger.info(f"  Files cleaned: {result['cleaned_files']}")
+            logger.info(f"  Space freed: {result['size_freed_bytes']:,} bytes")
             
             if result.get('s3_files_cleaned'):
-                print(f"  S3 files cleaned: {result['s3_files_cleaned']}")
+                logger.info(f"  S3 files cleaned: {result['s3_files_cleaned']}")
         else:
-            print(f"✗ Backup cleanup failed: {result['error']}")
+            logger.error(f"✗ Backup cleanup failed: {result['error']}")
             return 1
         
         return 0
     
     except Exception as e:
-        print(f"✗ Backup cleanup failed: {e}")
+        logger.error(f"✗ Backup cleanup failed: {e}")
         return 1
 
 
@@ -212,40 +218,40 @@ def cmd_status(args):
         backup_service = create_backup_service()
         status = backup_service.get_backup_status()
         
-        print("Backup System Status")
-        print("=" * 50)
-        print(f"Status: {status['status']}")
-        print(f"Backup Directory: {status['backup_directory']}")
-        print(f"Total Backups: {status['total_backups']}")
-        print(f"Completed: {status['completed_backups']}")
-        print(f"Failed: {status['failed_backups']}")
-        print(f"Corrupted: {status['corrupted_backups']}")
-        print(f"Total Storage: {status['total_storage_bytes']:,} bytes")
-        print(f"S3 Enabled: {status['s3_enabled']}")
-        print(f"Compression: {status['compression_enabled']}")
-        print(f"Retention Days: {status['retention_days']}")
+        logger.info("Backup System Status")
+        logger.info("=" * 50)
+        logger.info(f"Status: {status['status']}")
+        logger.info(f"Backup Directory: {status['backup_directory']}")
+        logger.info(f"Total Backups: {status['total_backups']}")
+        logger.info(f"Completed: {status['completed_backups']}")
+        logger.error(f"Failed: {status['failed_backups']}")
+        logger.info(f"Corrupted: {status['corrupted_backups']}")
+        logger.info(f"Total Storage: {status['total_storage_bytes']:,} bytes")
+        logger.info(f"S3 Enabled: {status['s3_enabled']}")
+        logger.info(f"Compression: {status['compression_enabled']}")
+        logger.info(f"Retention Days: {status['retention_days']}")
         
         if status.get('latest_backup'):
             latest = status['latest_backup']
             created_at = datetime.fromisoformat(latest['created_at'])
-            print(f"\nLatest Backup:")
-            print(f"  ID: {latest['backup_id']}")
-            print(f"  Type: {latest['backup_type']}")
-            print(f"  Created: {created_at.strftime('%Y-%m-%d %H:%M:%S')}")
-            print(f"  Status: {latest['status']}")
+            logger.info(f"\nLatest Backup:")
+            logger.info(f"  ID: {latest['backup_id']}")
+            logger.info(f"  Type: {latest['backup_type']}")
+            logger.info(f"  Created: {created_at.strftime('%Y-%m-%d %H:%M:%S')}")
+            logger.info(f"  Status: {latest['status']}")
         
         # Disk usage
         disk = status['disk_usage']
-        print(f"\nDisk Usage:")
-        print(f"  Total: {disk['total_bytes']:,} bytes")
-        print(f"  Used: {disk['used_bytes']:,} bytes")
-        print(f"  Free: {disk['free_bytes']:,} bytes")
-        print(f"  Usage: {disk['usage_percentage']:.1f}%")
+        logger.info(f"\nDisk Usage:")
+        logger.info(f"  Total: {disk['total_bytes']:,} bytes")
+        logger.info(f"  Used: {disk['used_bytes']:,} bytes")
+        logger.info(f"  Free: {disk['free_bytes']:,} bytes")
+        logger.info(f"  Usage: {disk['usage_percentage']:.1f}%")
         
         return 0
     
     except Exception as e:
-        print(f"✗ Failed to get backup status: {e}")
+        logger.error(f"✗ Failed to get backup status: {e}")
         return 1
 
 

--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -1,0 +1,12 @@
+import logging
+from .core.config import settings
+
+def configure_logging():
+    """Configure logging level and format."""
+    level = logging.DEBUG if getattr(settings, "debug", False) else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,12 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 import os
+import logging
+
+from .logging_config import configure_logging
+
+configure_logging()
+logger = logging.getLogger(__name__)
 
 from .core.config import settings
 from .core.cors_middleware import CustomCORSMiddleware
@@ -14,7 +20,7 @@ from fastapi import Request, Response
 async def lifespan(app: FastAPI):
     """Application lifespan manager."""
     # Startup
-    print("Starting Kruzna Karta Hrvatska API...")
+    logger.info("Starting Kruzna Karta Hrvatska API...")
     
     # Start scheduler if enabled
     enable_scheduler = os.getenv("ENABLE_SCHEDULER", "false").lower() == "true"
@@ -29,7 +35,7 @@ async def lifespan(app: FastAPI):
     if enable_scheduler:
         from .tasks.scheduler import stop_scheduler
         stop_scheduler()
-    print("Shutting down Kruzna Karta Hrvatska API...")
+    logger.info("Shutting down Kruzna Karta Hrvatska API...")
 
 app = FastAPI(
     title="Kruzna Karta Hrvatska API",

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -2,6 +2,9 @@ from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
 from sqlalchemy.orm import Session
 from datetime import datetime, timedelta
 from typing import Optional
+import logging
+
+from ..logging_config import configure_logging
 
 from ..core.database import get_db
 from ..core.auth import (
@@ -21,17 +24,20 @@ from ..models.user_schemas import (
 
 router = APIRouter(prefix="/auth", tags=["authentication"])
 
+configure_logging()
+logger = logging.getLogger(__name__)
+
 
 def send_verification_email(email: str, token: str):
     """Send email verification email (placeholder for actual email service)."""
     # TODO: Implement actual email sending
-    print(f"Verification email for {email}: {settings.frontend_url}/verify-email?token={token}")
+    logger.debug("Verification email sent to %s", email)
 
 
 def send_password_reset_email(email: str, token: str):
     """Send password reset email (placeholder for actual email service)."""
     # TODO: Implement actual email sending
-    print(f"Password reset email for {email}: {settings.frontend_url}/reset-password?token={token}")
+    logger.debug("Password reset email sent to %s", email)
 
 
 @router.post("/register", response_model=AuthResponse)

--- a/backend/app/routes/scraping.py
+++ b/backend/app/routes/scraping.py
@@ -2,12 +2,18 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 from pydantic import BaseModel
 from typing import Optional, Dict, Any
 import asyncio
+import logging
+
+from ..logging_config import configure_logging
 
 from ..scraping.entrio_scraper import scrape_entrio_events
 from ..scraping.croatia_scraper import scrape_croatia_events
 from ..scraping.enhanced_scraper import run_enhanced_scraping_pipeline, run_single_source_enhanced_scraping
 
 router = APIRouter(prefix="/scraping", tags=["scraping"])
+
+configure_logging()
+logger = logging.getLogger(__name__)
 
 
 class ScrapeResponse(BaseModel):
@@ -41,10 +47,10 @@ async def run_scraping_task(max_pages: int, task_id: str):
         result = await scrape_entrio_events(max_pages=max_pages)
         # In a real implementation, you'd store this result somewhere
         # accessible by task_id (Redis, database, etc.)
-        print(f"Scraping task {task_id} completed: {result}")
+        logger.info(f"Scraping task {task_id} completed: {result}")
         return result
     except Exception as e:
-        print(f"Scraping task {task_id} failed: {e}")
+        logger.error(f"Scraping task {task_id} failed: {e}")
         return {"status": "error", "message": str(e)}
 
 
@@ -289,11 +295,11 @@ async def enhanced_scraping_pipeline(
                     max_pages_per_source=request.max_pages_per_source,
                     quality_threshold=request.quality_threshold
                 )
-                print(f"Enhanced scraping task {task_id} completed successfully")
-                print(result.get("performance_report", "No performance report available"))
+                logger.info(f"Enhanced scraping task {task_id} completed successfully")
+                logger.info(result.get("performance_report", "No performance report available"))
                 return result
             except Exception as e:
-                print(f"Enhanced scraping task {task_id} failed: {e}")
+                logger.error(f"Enhanced scraping task {task_id} failed: {e}")
                 return {"status": "error", "message": str(e), "task_id": task_id}
         
         background_tasks.add_task(run_enhanced_background_task)
@@ -364,10 +370,10 @@ async def enhanced_single_source_scraping(
                     max_pages=request.max_pages,
                     quality_threshold=request.quality_threshold
                 )
-                print(f"Enhanced {request.source} scraping task {task_id} completed")
+                logger.info(f"Enhanced {request.source} scraping task {task_id} completed")
                 return result
             except Exception as e:
-                print(f"Enhanced {request.source} scraping task {task_id} failed: {e}")
+                logger.error(f"Enhanced {request.source} scraping task {task_id} failed: {e}")
                 return {"status": "error", "message": str(e), "task_id": task_id}
         
         background_tasks.add_task(run_single_source_background_task)
@@ -403,7 +409,7 @@ async def enhanced_scraping_demo(
         if source.lower() not in ["entrio", "croatia"]:
             raise HTTPException(status_code=400, detail="Source must be 'entrio' or 'croatia'")
         
-        print(f"Starting enhanced scraping demo for {source} ({max_pages} pages)")
+        logger.info(f"Starting enhanced scraping demo for {source} ({max_pages} pages)")
         
         result = await run_single_source_enhanced_scraping(
             source=source,

--- a/backend/app/scraping/croatia_scraper.py
+++ b/backend/app/scraping/croatia_scraper.py
@@ -15,6 +15,9 @@ import requests
 from bs4 import BeautifulSoup, Tag
 import pandas as pd
 from sqlalchemy.orm import Session
+import logging
+
+from ..logging_config import configure_logging
 
 from ..core.config import settings
 from ..core.database import SessionLocal
@@ -33,6 +36,9 @@ BRD_WSS = f"wss://{USER}:{PASSWORD}@brd.superproxy.io:9222"
 USE_SB = os.getenv("USE_SCRAPING_BROWSER", "0") == "1"
 USE_PROXY = os.getenv("USE_PROXY", "0") == "1"
 USE_PLAYWRIGHT = os.getenv("USE_PLAYWRIGHT", "1") == "1"
+
+configure_logging()
+logger = logging.getLogger(__name__)
 
 HEADERS = {
     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
@@ -236,7 +242,7 @@ class CroatiaEventDataTransformer:
             )
         
         except Exception as e:
-            print(f"Error transforming Croatia.hr event data: {e}")
+            logger.error(f"Error transforming Croatia.hr event data: {e}")
             return None
 
 
@@ -259,11 +265,11 @@ class CroatiaPlaywrightScraper:
             page = await browser.new_page()
             
             try:
-                print(f"→ Fetching Croatia.hr events from {start_url}")
+                logger.info(f"→ Fetching Croatia.hr events from {start_url}")
                 await page.goto(start_url, wait_until="domcontentloaded", timeout=90000)
                 
                 # Wait for Vue.js to load and render content
-                print("Waiting for Vue.js content to load...")
+                logger.info("Waiting for Vue.js content to load...")
                 await page.wait_for_timeout(5000)
                 
                 # Try to wait for event containers to appear
@@ -272,7 +278,7 @@ class CroatiaPlaywrightScraper:
                 page_count = 0
                 while page_count < max_pages:
                     page_count += 1
-                    print(f"Scraping page {page_count}...")
+                    logger.info(f"Scraping page {page_count}...")
                     
                     # Wait a bit more for dynamic content
                     await page.wait_for_timeout(3000)
@@ -420,7 +426,7 @@ class CroatiaPlaywrightScraper:
                     valid_events = [event for event in events_data if event.get('title') or event.get('link')]
                     all_events.extend(valid_events)
                     
-                    print(f"Page {page_count}: Found {len(valid_events)} events (Total: {len(all_events)})")
+                    logger.info(f"Page {page_count}: Found {len(valid_events)} events (Total: {len(all_events)})")
                     
                     # Try to find pagination or load more button
                     has_more = False
@@ -442,13 +448,13 @@ class CroatiaPlaywrightScraper:
                             if load_more:
                                 is_enabled = await load_more.is_enabled()
                                 if is_enabled:
-                                    print(f"Found load more button: {selector}")
+                                    logger.info(f"Found load more button: {selector}")
                                     await load_more.click()
                                     await page.wait_for_timeout(3000)  # Wait for new content
                                     has_more = True
                                     break
                         except Exception as e:
-                            print(f"Error clicking load more button: {e}")
+                            logger.error(f"Error clicking load more button: {e}")
                             continue
                     
                     # If no "load more" found, try scrolling to trigger infinite scroll
@@ -462,17 +468,17 @@ class CroatiaPlaywrightScraper:
                             new_events_data = await page.evaluate("document.querySelectorAll('a[href*=\"/dogadanja/\"], [class*=\"event\"]').length")
                             if new_events_data > len(eventElements if 'eventElements' in locals() else []):
                                 has_more = True
-                                print("Infinite scroll detected more content")
+                                logger.info("Infinite scroll detected more content")
                             
                         except Exception as e:
-                            print(f"Error with infinite scroll: {e}")
+                            logger.error(f"Error with infinite scroll: {e}")
                     
                     if not has_more or len(valid_events) == 0:
-                        print("No more pages found or no events on current page")
+                        logger.info("No more pages found or no events on current page")
                         break
                 
             except Exception as e:
-                print(f"Error during scraping: {e}")
+                logger.error(f"Error during scraping: {e}")
             
             finally:
                 await browser.close()
@@ -489,12 +495,12 @@ class CroatiaScraper:
     
     async def scrape_events(self, max_pages: int = 5) -> List[EventCreate]:
         """Scrape events and return as EventCreate objects."""
-        print(f"Starting Croatia.hr scraper (max_pages: {max_pages})")
+        logger.info(f"Starting Croatia.hr scraper (max_pages: {max_pages})")
         
         # Scrape raw data using Playwright (required for Vue.js content)
         raw_events = await self.playwright_scraper.scrape_with_playwright(max_pages=max_pages)
         
-        print(f"Scraped {len(raw_events)} raw events from Croatia.hr")
+        logger.info(f"Scraped {len(raw_events)} raw events from Croatia.hr")
         
         # Transform to EventCreate objects
         events = []
@@ -503,7 +509,7 @@ class CroatiaScraper:
             if event:
                 events.append(event)
         
-        print(f"Transformed {len(events)} valid events for Croatia.hr")
+        logger.info(f"Transformed {len(events)} valid events for Croatia.hr")
         return events
     
     def save_events_to_database(self, events: List[EventCreate]) -> int:
@@ -527,13 +533,13 @@ class CroatiaScraper:
                     db.add(db_event)
                     saved_count += 1
                 else:
-                    print(f"Event already exists: {event_data.name}")
+                    logger.info(f"Event already exists: {event_data.name}")
             
             db.commit()
-            print(f"Saved {saved_count} new events to database from Croatia.hr")
+            logger.info(f"Saved {saved_count} new events to database from Croatia.hr")
             
         except Exception as e:
-            print(f"Error saving Croatia.hr events to database: {e}")
+            logger.error(f"Error saving Croatia.hr events to database: {e}")
             db.rollback()
             raise
         finally:

--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -9,11 +9,17 @@ import time
 from datetime import datetime
 from typing import Callable, Any
 import threading
+import logging
+
+from ..logging_config import configure_logging
 
 from ..scraping.entrio_scraper import scrape_entrio_events
 from ..scraping.croatia_scraper import scrape_croatia_events
 from ..scraping.enhanced_scraper import run_enhanced_scraping_pipeline
 from .analytics_tasks import analytics_scheduler
+
+configure_logging()
+logger = logging.getLogger(__name__)
 
 
 class SimpleScheduler:
@@ -31,14 +37,14 @@ class SimpleScheduler:
         self.running = True
         self.scheduler_thread = threading.Thread(target=self._run_scheduler, daemon=True)
         self.scheduler_thread.start()
-        print("Scheduler started")
+        logger.info("Scheduler started")
     
     def stop(self):
         """Stop the scheduler."""
         self.running = False
         if self.scheduler_thread:
             self.scheduler_thread.join(timeout=5)
-        print("Scheduler stopped")
+        logger.info("Scheduler stopped")
     
     def _run_scheduler(self):
         """Run the scheduler loop."""
@@ -49,12 +55,12 @@ class SimpleScheduler:
     def schedule_daily_scraping(self, hour: int = 2, minute: int = 0):
         """Schedule daily scraping at specified time."""
         schedule.every().day.at(f"{hour:02d}:{minute:02d}").do(self._daily_scrape_job)
-        print(f"Scheduled daily scraping at {hour:02d}:{minute:02d}")
+        logger.info(f"Scheduled daily scraping at {hour:02d}:{minute:02d}")
     
     def schedule_hourly_scraping(self):
         """Schedule scraping every hour."""
         schedule.every().hour.do(self._hourly_scrape_job)
-        print("Scheduled hourly scraping")
+        logger.info("Scheduled hourly scraping")
     
     def schedule_analytics_tasks(self):
         """Schedule analytics aggregation and monitoring tasks."""
@@ -73,12 +79,12 @@ class SimpleScheduler:
         # Cleanup old raw data weekly on Sunday at 6 AM
         schedule.every().sunday.at("06:00").do(self._cleanup_analytics_job)
         
-        print("Scheduled analytics tasks:")
-        print("- Daily metrics aggregation at 03:00")
-        print("- Weekly metrics aggregation on Monday at 04:00") 
-        print("- Monthly metrics aggregation on 1st at 05:00")
-        print("- Metric alerts check every 6 hours")
-        print("- Analytics cleanup on Sunday at 06:00")
+        logger.info("Scheduled analytics tasks:")
+        logger.info("- Daily metrics aggregation at 03:00")
+        logger.info("- Weekly metrics aggregation on Monday at 04:00") 
+        logger.info("- Monthly metrics aggregation on 1st at 05:00")
+        logger.info("- Metric alerts check every 6 hours")
+        logger.info("- Analytics cleanup on Sunday at 06:00")
     
     def schedule_backup_tasks(self):
         """Schedule automated backup tasks."""
@@ -91,10 +97,10 @@ class SimpleScheduler:
         # Weekly backup cleanup on Sunday at 7 AM (after analytics cleanup)
         schedule.every().sunday.at("07:00").do(self._backup_cleanup_job)
         
-        print("Scheduled backup tasks:")
-        print("- Daily full backup at 01:00")
-        print("- Weekly schema backup on Sunday at 01:30")
-        print("- Weekly backup cleanup on Sunday at 07:00")
+        logger.info("Scheduled backup tasks:")
+        logger.info("- Daily full backup at 01:00")
+        logger.info("- Weekly schema backup on Sunday at 01:30")
+        logger.info("- Weekly backup cleanup on Sunday at 07:00")
     
     def schedule_monitoring_tasks(self):
         """Schedule automated monitoring tasks."""
@@ -104,17 +110,17 @@ class SimpleScheduler:
         # Check alerts every 2 minutes
         schedule.every(2).minutes.do(self._check_monitoring_alerts_job)
         
-        print("Scheduled monitoring tasks:")
-        print("- Metrics update every 30 seconds")
-        print("- Alert checking every 2 minutes")
+        logger.info("Scheduled monitoring tasks:")
+        logger.info("- Metrics update every 30 seconds")
+        logger.info("- Alert checking every 2 minutes")
     
     def schedule_gdpr_tasks(self):
         """Schedule automated GDPR compliance tasks."""
         # Daily GDPR data retention cleanup at 4 AM (after analytics)
         schedule.every().day.at("04:00").do(self._gdpr_data_retention_cleanup_job)
         
-        print("Scheduled GDPR compliance tasks:")
-        print("- Daily data retention cleanup at 04:00")
+        logger.info("Scheduled GDPR compliance tasks:")
+        logger.info("- Daily data retention cleanup at 04:00")
     
     def schedule_croatian_tasks(self):
         """Schedule Croatian-specific tasks."""
@@ -124,13 +130,13 @@ class SimpleScheduler:
         # Cache Croatian holidays at midnight on January 1st
         schedule.every().day.at("00:01").do(self._update_croatian_holidays_cache_job)
         
-        print("Scheduled Croatian localization tasks:")
-        print("- Currency rates update every hour")
-        print("- Holiday cache update daily at 00:01")
+        logger.info("Scheduled Croatian localization tasks:")
+        logger.info("- Currency rates update every hour")
+        logger.info("- Holiday cache update daily at 00:01")
     
     def _daily_scrape_job(self):
         """Daily scraping job with enhanced pipeline (comprehensive)."""
-        print(f"Starting enhanced daily scraping job at {datetime.now()}")
+        logger.info(f"Starting enhanced daily scraping job at {datetime.now()}")
         try:
             # Use enhanced scraping pipeline for better quality
             result = asyncio.run(run_enhanced_scraping_pipeline(
@@ -140,19 +146,19 @@ class SimpleScheduler:
             
             # Log detailed results
             performance = result.get("performance_analysis", {}).get("performance_metrics", {})
-            print(f"Daily scraping completed: {performance.get('total_events_scraped', 0)} scraped, "
+            logger.info(f"Daily scraping completed: {performance.get('total_events_scraped', 0)} scraped, "
                   f"{performance.get('total_events_saved', 0)} saved")
             
             # Print performance report if available
             if result.get("performance_report"):
-                print(result["performance_report"])
+                logger.info(result["performance_report"])
                 
         except Exception as e:
-            print(f"Enhanced daily scraping job failed: {e}")
+            logger.error(f"Enhanced daily scraping job failed: {e}")
     
     def _hourly_scrape_job(self):
         """Hourly scraping job with enhanced pipeline (quick check)."""
-        print(f"Starting enhanced hourly scraping job at {datetime.now()}")
+        logger.info(f"Starting enhanced hourly scraping job at {datetime.now()}")
         try:
             # Use enhanced scraping pipeline with lower threshold for hourly updates
             result = asyncio.run(run_enhanced_scraping_pipeline(
@@ -162,11 +168,11 @@ class SimpleScheduler:
             
             # Log brief results
             performance = result.get("performance_analysis", {}).get("performance_metrics", {})
-            print(f"Hourly scraping completed: {performance.get('total_events_scraped', 0)} scraped, "
+            logger.info(f"Hourly scraping completed: {performance.get('total_events_scraped', 0)} scraped, "
                   f"{performance.get('total_events_saved', 0)} saved")
                   
         except Exception as e:
-            print(f"Enhanced hourly scraping job failed: {e}")
+            logger.error(f"Enhanced hourly scraping job failed: {e}")
     
     async def _run_all_scraping_tasks(self, max_pages: int):
         """Execute scraping tasks for all supported sites."""
@@ -176,78 +182,78 @@ class SimpleScheduler:
         try:
             entrio_result = await scrape_entrio_events(max_pages=max_pages)
             results.append(("Entrio.hr", entrio_result))
-            print(f"Entrio.hr scraping completed: {entrio_result}")
+            logger.info(f"Entrio.hr scraping completed: {entrio_result}")
         except Exception as e:
-            print(f"Entrio.hr scraping failed: {e}")
+            logger.error(f"Entrio.hr scraping failed: {e}")
             results.append(("Entrio.hr", {"status": "error", "message": str(e)}))
         
         # Scrape Croatia.hr
         try:
             croatia_result = await scrape_croatia_events(max_pages=max_pages)
             results.append(("Croatia.hr", croatia_result))
-            print(f"Croatia.hr scraping completed: {croatia_result}")
+            logger.info(f"Croatia.hr scraping completed: {croatia_result}")
         except Exception as e:
-            print(f"Croatia.hr scraping failed: {e}")
+            logger.error(f"Croatia.hr scraping failed: {e}")
             results.append(("Croatia.hr", {"status": "error", "message": str(e)}))
         
         # Summary
         total_scraped = sum(result[1].get("scraped_events", 0) for _, result in results if result.get("status") == "success")
         total_saved = sum(result[1].get("saved_events", 0) for _, result in results if result.get("status") == "success")
         
-        print(f"All sites scraping completed: {total_scraped} events scraped, {total_saved} new events saved")
+        logger.info(f"All sites scraping completed: {total_scraped} events scraped, {total_saved} new events saved")
         return results
     
     def _daily_analytics_job(self):
         """Daily analytics aggregation job."""
-        print(f"Starting daily analytics aggregation at {datetime.now()}")
+        logger.info(f"Starting daily analytics aggregation at {datetime.now()}")
         try:
             analytics_scheduler.aggregate_yesterday_metrics()
             analytics_scheduler.generate_analytics_report()
-            print("Daily analytics aggregation completed")
+            logger.info("Daily analytics aggregation completed")
         except Exception as e:
-            print(f"Daily analytics aggregation failed: {e}")
+            logger.error(f"Daily analytics aggregation failed: {e}")
     
     def _weekly_analytics_job(self):
         """Weekly analytics aggregation job."""
-        print(f"Starting weekly analytics aggregation at {datetime.now()}")
+        logger.info(f"Starting weekly analytics aggregation at {datetime.now()}")
         try:
             analytics_scheduler.aggregate_weekly_metrics()
-            print("Weekly analytics aggregation completed")
+            logger.info("Weekly analytics aggregation completed")
         except Exception as e:
-            print(f"Weekly analytics aggregation failed: {e}")
+            logger.error(f"Weekly analytics aggregation failed: {e}")
     
     def _monthly_analytics_job(self):
         """Monthly analytics aggregation job."""
         from datetime import date
         if date.today().day == 1:  # Only run on first day of month
-            print(f"Starting monthly analytics aggregation at {datetime.now()}")
+            logger.info(f"Starting monthly analytics aggregation at {datetime.now()}")
             try:
                 analytics_scheduler.aggregate_monthly_metrics()
-                print("Monthly analytics aggregation completed")
+                logger.info("Monthly analytics aggregation completed")
             except Exception as e:
-                print(f"Monthly analytics aggregation failed: {e}")
+                logger.error(f"Monthly analytics aggregation failed: {e}")
     
     def _metric_alerts_job(self):
         """Metric alerts monitoring job."""
-        print(f"Starting metric alerts check at {datetime.now()}")
+        logger.info(f"Starting metric alerts check at {datetime.now()}")
         try:
             analytics_scheduler.check_metric_alerts()
-            print("Metric alerts check completed")
+            logger.info("Metric alerts check completed")
         except Exception as e:
-            print(f"Metric alerts check failed: {e}")
+            logger.error(f"Metric alerts check failed: {e}")
     
     def _cleanup_analytics_job(self):
         """Analytics data cleanup job."""
-        print(f"Starting analytics cleanup at {datetime.now()}")
+        logger.info(f"Starting analytics cleanup at {datetime.now()}")
         try:
             analytics_scheduler.cleanup_old_raw_data(retention_days=90)
-            print("Analytics cleanup completed")
+            logger.info("Analytics cleanup completed")
         except Exception as e:
-            print(f"Analytics cleanup failed: {e}")
+            logger.error(f"Analytics cleanup failed: {e}")
     
     def _daily_backup_job(self):
         """Daily backup job."""
-        print(f"Starting daily database backup at {datetime.now()}")
+        logger.info(f"Starting daily database backup at {datetime.now()}")
         try:
             from ..core.backup import get_backup_service
             backup_service = get_backup_service()
@@ -257,31 +263,31 @@ class SimpleScheduler:
                 include_analytics=True
             )
             
-            print(f"Daily backup completed: {metadata.backup_id} ({metadata.file_size:,} bytes)")
+            logger.info(f"Daily backup completed: {metadata.backup_id} ({metadata.file_size:,} bytes)")
             
             if metadata.storage_location:
-                print(f"Backup uploaded to S3: {metadata.storage_location}")
+                logger.info(f"Backup uploaded to S3: {metadata.storage_location}")
                 
         except Exception as e:
-            print(f"Daily backup failed: {e}")
+            logger.error(f"Daily backup failed: {e}")
     
     def _weekly_schema_backup_job(self):
         """Weekly schema backup job."""
-        print(f"Starting weekly schema backup at {datetime.now()}")
+        logger.info(f"Starting weekly schema backup at {datetime.now()}")
         try:
             from ..core.backup import get_backup_service
             backup_service = get_backup_service()
             
             metadata = backup_service.create_schema_backup()
             
-            print(f"Weekly schema backup completed: {metadata.backup_id} ({metadata.file_size:,} bytes)")
+            logger.info(f"Weekly schema backup completed: {metadata.backup_id} ({metadata.file_size:,} bytes)")
                 
         except Exception as e:
-            print(f"Weekly schema backup failed: {e}")
+            logger.error(f"Weekly schema backup failed: {e}")
     
     def _backup_cleanup_job(self):
         """Backup cleanup job."""
-        print(f"Starting backup cleanup at {datetime.now()}")
+        logger.info(f"Starting backup cleanup at {datetime.now()}")
         try:
             from ..core.backup import get_backup_service
             backup_service = get_backup_service()
@@ -289,15 +295,15 @@ class SimpleScheduler:
             result = backup_service.cleanup_old_backups()
             
             if result['status'] == 'success':
-                print(f"Backup cleanup completed: {result['cleaned_files']} files, "
+                logger.info(f"Backup cleanup completed: {result['cleaned_files']} files, "
                       f"{result['size_freed_bytes']:,} bytes freed")
                 if result.get('s3_files_cleaned'):
-                    print(f"S3 files cleaned: {result['s3_files_cleaned']}")
+                    logger.info(f"S3 files cleaned: {result['s3_files_cleaned']}")
             else:
-                print(f"Backup cleanup failed: {result['error']}")
+                logger.error(f"Backup cleanup failed: {result['error']}")
                 
         except Exception as e:
-            print(f"Backup cleanup failed: {e}")
+            logger.error(f"Backup cleanup failed: {e}")
     
     def _update_monitoring_metrics_job(self):
         """Update monitoring metrics job."""
@@ -310,7 +316,7 @@ class SimpleScheduler:
             asyncio.run(monitoring_service.update_prometheus_metrics())
             
         except Exception as e:
-            print(f"Monitoring metrics update failed: {e}")
+            logger.error(f"Monitoring metrics update failed: {e}")
     
     def _check_monitoring_alerts_job(self):
         """Check monitoring alerts job."""
@@ -325,16 +331,16 @@ class SimpleScheduler:
             # Log critical alerts
             critical_alerts = [a for a in alerts if a['severity'] == 'critical']
             if critical_alerts:
-                print(f"CRITICAL ALERTS: {len(critical_alerts)} critical alerts detected")
+                logger.info(f"CRITICAL ALERTS: {len(critical_alerts)} critical alerts detected")
                 for alert in critical_alerts:
-                    print(f"  - {alert['message']}")
+                    logger.info(f"  - {alert['message']}")
             
         except Exception as e:
-            print(f"Monitoring alerts check failed: {e}")
+            logger.error(f"Monitoring alerts check failed: {e}")
     
     def _gdpr_data_retention_cleanup_job(self):
         """GDPR data retention cleanup job."""
-        print(f"Starting GDPR data retention cleanup at {datetime.now()}")
+        logger.info(f"Starting GDPR data retention cleanup at {datetime.now()}")
         try:
             from ..core.security import get_gdpr_service
             gdpr_service = get_gdpr_service()
@@ -342,18 +348,18 @@ class SimpleScheduler:
             result = gdpr_service.run_data_retention_cleanup()
             
             if result['status'] == 'completed':
-                print(f"GDPR cleanup completed: {len(result['actions'])} actions")
+                logger.info(f"GDPR cleanup completed: {len(result['actions'])} actions")
                 for action in result['actions']:
-                    print(f"  - {action}")
+                    logger.info(f"  - {action}")
             else:
-                print(f"GDPR cleanup failed: {result['message']}")
+                logger.error(f"GDPR cleanup failed: {result['message']}")
                 
         except Exception as e:
-            print(f"GDPR data retention cleanup failed: {e}")
+            logger.error(f"GDPR data retention cleanup failed: {e}")
     
     def _update_croatian_currency_rates_job(self):
         """Update Croatian currency exchange rates."""
-        print(f"Starting Croatian currency rates update at {datetime.now()}")
+        logger.info(f"Starting Croatian currency rates update at {datetime.now()}")
         try:
             from ..core.croatian import get_croatian_currency_service
             currency_service = get_croatian_currency_service()
@@ -361,14 +367,14 @@ class SimpleScheduler:
             # Force update of exchange rates
             currency_service._update_exchange_rates()
             
-            print("Croatian currency rates updated successfully")
+            logger.info("Croatian currency rates updated successfully")
                 
         except Exception as e:
-            print(f"Croatian currency rates update failed: {e}")
+            logger.error(f"Croatian currency rates update failed: {e}")
     
     def _update_croatian_holidays_cache_job(self):
         """Update Croatian holidays cache."""
-        print(f"Starting Croatian holidays cache update at {datetime.now()}")
+        logger.info(f"Starting Croatian holidays cache update at {datetime.now()}")
         try:
             from ..core.croatian import get_croatian_holiday_service
             from datetime import datetime
@@ -383,12 +389,12 @@ class SimpleScheduler:
             for year in years_to_cache:
                 holidays = holiday_service.get_croatian_holidays(year)
                 total_holidays += len(holidays)
-                print(f"  - Cached {len(holidays)} holidays for {year}")
+                logger.info(f"  - Cached {len(holidays)} holidays for {year}")
             
-            print(f"Croatian holidays cache updated: {total_holidays} total holidays cached")
+            logger.info(f"Croatian holidays cache updated: {total_holidays} total holidays cached")
                 
         except Exception as e:
-            print(f"Croatian holidays cache update failed: {e}")
+            logger.error(f"Croatian holidays cache update failed: {e}")
 
 
 # Global scheduler instance
@@ -418,14 +424,14 @@ def setup_default_schedule():
     # Start the scheduler
     scheduler.start()
     
-    print("Default production schedule configured:")
-    print("- Daily scraping at 02:00 (10 pages per site)")
-    print("- Sites: Entrio.hr, Croatia.hr")
-    print("- Analytics aggregation and monitoring enabled")
-    print("- Automated backup and disaster recovery enabled")
-    print("- Real-time monitoring and alerting enabled")
-    print("- GDPR compliance and data retention enabled")
-    print("- Croatian localization features enabled")
+    logger.info("Default production schedule configured:")
+    logger.info("- Daily scraping at 02:00 (10 pages per site)")
+    logger.info("- Sites: Entrio.hr, Croatia.hr")
+    logger.info("- Analytics aggregation and monitoring enabled")
+    logger.info("- Automated backup and disaster recovery enabled")
+    logger.info("- Real-time monitoring and alerting enabled")
+    logger.info("- GDPR compliance and data retention enabled")
+    logger.info("- Croatian localization features enabled")
 
 
 def setup_development_schedule():
@@ -451,14 +457,14 @@ def setup_development_schedule():
     # Start the scheduler
     scheduler.start()
     
-    print("Development schedule configured:")
-    print("- Hourly scraping (2 pages per site)")
-    print("- Sites: Entrio.hr, Croatia.hr")
-    print("- Analytics aggregation and monitoring enabled")
-    print("- Automated backup and disaster recovery enabled")
-    print("- Real-time monitoring and alerting enabled")
-    print("- GDPR compliance and data retention enabled")
-    print("- Croatian localization features enabled")
+    logger.info("Development schedule configured:")
+    logger.info("- Hourly scraping (2 pages per site)")
+    logger.info("- Sites: Entrio.hr, Croatia.hr")
+    logger.info("- Analytics aggregation and monitoring enabled")
+    logger.info("- Automated backup and disaster recovery enabled")
+    logger.info("- Real-time monitoring and alerting enabled")
+    logger.info("- GDPR compliance and data retention enabled")
+    logger.info("- Croatian localization features enabled")
 
 
 # Startup function to be called from main.py

--- a/backend/manage_db.py
+++ b/backend/manage_db.py
@@ -8,51 +8,57 @@ import os
 import sys
 import argparse
 from pathlib import Path
+import logging
+
+from app.logging_config import configure_logging
 
 # Add the project root to Python path
 sys.path.append(os.path.dirname(__file__))
 
+configure_logging()
+logger = logging.getLogger(__name__)
+
 def run_migrations():
     """Run all pending migrations."""
-    print("Running database migrations...")
+    logger.info("Running database migrations...")
     os.system(".venv/bin/alembic upgrade head")
 
 def create_migration(message):
     """Create a new migration with autogenerate."""
-    print(f"Creating new migration: {message}")
+    logger.info("Creating new migration: %s", message)
     os.system(f'.venv/bin/alembic revision --autogenerate -m "{message}"')
 
 def rollback_migration():
     """Rollback the last migration."""
-    print("Rolling back last migration...")
+    logger.info("Rolling back last migration...")
     os.system(".venv/bin/alembic downgrade -1")
 
 def show_current_revision():
     """Show current database revision."""
-    print("Current database revision:")
+    logger.info("Current database revision:")
     os.system(".venv/bin/alembic current")
 
 def show_migration_history():
     """Show migration history."""
-    print("Migration history:")
+    logger.info("Migration history:")
     os.system(".venv/bin/alembic history")
 
 def reset_database():
     """Reset database to base (WARNING: This will delete all data!)."""
     response = input("WARNING: This will delete all data! Are you sure? (yes/no): ")
     if response.lower() == 'yes':
-        print("Resetting database...")
+        logger.info("Resetting database...")
         os.system(".venv/bin/alembic downgrade base")
-        print("Database reset complete.")
+        logger.info("Database reset complete.")
     else:
-        print("Database reset cancelled.")
+        logger.info("Database reset cancelled.")
 
 def setup_database():
     """Set up database from scratch."""
-    print("Setting up database from scratch...")
-    print("1. Running migrations...")
+    logger.info("Setting up database from scratch...")
+    logger.info("1. Running migrations...")
     run_migrations()
-    print("Database setup complete!")
+    logger.info("Database setup complete!")
 
 def main():
     parser = argparse.ArgumentParser(description='Database management for Kruzna Karta Hrvatska')

--- a/backend/scripts/setup_database.py
+++ b/backend/scripts/setup_database.py
@@ -7,9 +7,15 @@ This script creates the database tables and inserts sample data.
 import os
 import sys
 from datetime import date
+import logging
+
+from app.logging_config import configure_logging
 
 # Add the parent directory to the path to import our app modules
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+configure_logging()
+logger = logging.getLogger(__name__)
 
 from sqlalchemy import create_engine
 from app.core.config import settings
@@ -20,22 +26,22 @@ from app.core.database import SessionLocal
 
 def create_tables():
     """Create all database tables."""
-    print("Creating database tables...")
+    logger.info("Creating database tables...")
     engine = create_engine(settings.database_url)
     Base.metadata.create_all(bind=engine)
-    print("Tables created successfully!")
+    logger.info("Tables created successfully!")
 
 
 def insert_sample_data():
     """Insert sample events data."""
-    print("Inserting sample data...")
+    logger.info("Inserting sample data...")
     
     db = SessionLocal()
     try:
         # Check if we already have data
         existing_events = db.query(Event).count()
         if existing_events > 0:
-            print(f"Database already contains {existing_events} events. Skipping sample data insertion.")
+            logger.info(f"Database already contains {existing_events} events. Skipping sample data insertion.")
             return
 
         sample_events = [
@@ -93,13 +99,13 @@ def insert_sample_data():
 
         for event in sample_events:
             db.add(event)
-            print(f"Added event: {event.name}")
+            logger.info(f"Added event: {event.name}")
 
         db.commit()
-        print("Sample data inserted successfully!")
+        logger.info("Sample data inserted successfully!")
 
     except Exception as e:
-        print(f"Error inserting sample data: {e}")
+        logger.error(f"Error inserting sample data: {e}")
         db.rollback()
         raise
     finally:
@@ -108,18 +114,18 @@ def insert_sample_data():
 
 def main():
     """Main setup function."""
-    print("Setting up Kruzna Karta Hrvatska database...")
-    print(f"Database URL: {settings.database_url}")
+    logger.info("Setting up Kruzna Karta Hrvatska database...")
+    logger.info(f"Database URL: {settings.database_url}")
     
     try:
         create_tables()
         insert_sample_data()
-        print("\n✅ Database setup completed successfully!")
-        print("\nYou can now start the backend server with:")
-        print("cd backend && uv run uvicorn app.main:app --reload")
+        logger.info("\n✅ Database setup completed successfully!")
+        logger.info("\nYou can now start the backend server with:")
+        logger.info("cd backend && uv run uvicorn app.main:app --reload")
         
     except Exception as e:
-        print(f"\n❌ Database setup failed: {e}")
+        logger.error(f"\n❌ Database setup failed: {e}")
         sys.exit(1)
 
 

--- a/backend/scripts/test_croatia_scraper.py
+++ b/backend/scripts/test_croatia_scraper.py
@@ -8,56 +8,62 @@ import sys
 import os
 import json
 from datetime import datetime
+import logging
+
+from app.logging_config import configure_logging
 
 # Add the parent directory to the path to import our app modules
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+configure_logging()
+logger = logging.getLogger(__name__)
 
 from app.scraping.croatia_scraper import CroatiaScraper
 
 
 async def test_croatia_scraper():
     """Test the Croatia.hr scraper and verify data quality."""
-    print("=" * 60)
-    print("Croatia.hr Scraper Test")
-    print("=" * 60)
+    logger.info("=" * 60)
+    logger.info("Croatia.hr Scraper Test")
+    logger.info("=" * 60)
     
     scraper = CroatiaScraper()
     
     try:
-        print("Starting Croatia.hr scraper test (max 1 page)...")
-        print(f"Target URL: https://croatia.hr/hr-hr/dogadanja")
-        print("-" * 60)
+        logger.info("Starting Croatia.hr scraper test (max 1 page)...")
+        logger.info(f"Target URL: https://croatia.hr/hr-hr/dogadanja")
+        logger.info("-" * 60)
         
         # Test with just 1 page for quick verification
         events = await scraper.scrape_events(max_pages=1)
         
-        print(f"\n✅ Scraping completed!")
-        print(f"📊 Found {len(events)} valid events")
+        logger.info(f"\n✅ Scraping completed!")
+        logger.info(f"📊 Found {len(events)} valid events")
         
         if events:
-            print("\n" + "=" * 40)
-            print("SAMPLE EVENTS DATA")
-            print("=" * 40)
+            logger.info("\n" + "=" * 40)
+            logger.info("SAMPLE EVENTS DATA")
+            logger.info("=" * 40)
             
             # Show first 3 events with detailed info
             for i, event in enumerate(events[:3], 1):
-                print(f"\n📅 Event {i}:")
-                print(f"   Name: {event.name}")
-                print(f"   Date: {event.date}")
-                print(f"   Time: {event.time}")
-                print(f"   Location: {event.location}")
-                print(f"   Price: {event.price}")
-                print(f"   Description: {event.description[:100]}..." if len(event.description) > 100 else f"   Description: {event.description}")
-                print(f"   Image: {event.image}")
-                print(f"   Link: {event.link}")
+                logger.info(f"\n📅 Event {i}:")
+                logger.info(f"   Name: {event.name}")
+                logger.info(f"   Date: {event.date}")
+                logger.info(f"   Time: {event.time}")
+                logger.info(f"   Location: {event.location}")
+                logger.info(f"   Price: {event.price}")
+                logger.info(f"   Description: {event.description[:100]}..." if len(event.description) > 100 else f"   Description: {event.description}")
+                logger.info(f"   Image: {event.image}")
+                logger.info(f"   Link: {event.link}")
             
             if len(events) > 3:
-                print(f"\n... and {len(events) - 3} more events")
+                logger.info(f"\n... and {len(events) - 3} more events")
             
             # Data quality analysis
-            print("\n" + "=" * 40)
-            print("DATA QUALITY ANALYSIS")
-            print("=" * 40)
+            logger.info("\n" + "=" * 40)
+            logger.info("DATA QUALITY ANALYSIS")
+            logger.info("=" * 40)
             
             stats = {
                 "total_events": len(events),
@@ -72,7 +78,7 @@ async def test_croatia_scraper():
             
             for key, value in stats.items():
                 percentage = (value / stats["total_events"] * 100) if stats["total_events"] > 0 else 0
-                print(f"   {key.replace('_', ' ').title()}: {value}/{stats['total_events']} ({percentage:.1f}%)")
+                logger.info(f"   {key.replace('_', ' ').title()}: {value}/{stats['total_events']} ({percentage:.1f}%)")
             
             # Save test results
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -101,51 +107,51 @@ async def test_croatia_scraper():
             with open(filename, 'w', encoding='utf-8') as f:
                 json.dump(test_results, f, ensure_ascii=False, indent=2)
             
-            print(f"\n💾 Test results saved to: {filename}")
+            logger.info(f"\n💾 Test results saved to: {filename}")
             
             # Recommendations
-            print("\n" + "=" * 40)
-            print("RECOMMENDATIONS")
-            print("=" * 40)
+            logger.info("\n" + "=" * 40)
+            logger.info("RECOMMENDATIONS")
+            logger.info("=" * 40)
             
             if stats["events_with_names"] / stats["total_events"] < 0.8:
-                print("⚠️  Consider improving title extraction selectors")
+                logger.info("⚠️  Consider improving title extraction selectors")
             
             if stats["events_with_dates"] / stats["total_events"] < 0.7:
-                print("⚠️  Consider improving date extraction and parsing")
+                logger.info("⚠️  Consider improving date extraction and parsing")
             
             if stats["events_with_locations"] / stats["total_events"] < 0.5:
-                print("⚠️  Consider improving location extraction")
+                logger.info("⚠️  Consider improving location extraction")
             
             if stats["events_with_images"] / stats["total_events"] < 0.3:
-                print("⚠️  Consider improving image URL extraction")
+                logger.info("⚠️  Consider improving image URL extraction")
             
             if stats["events_with_links"] / stats["total_events"] < 0.8:
-                print("⚠️  Consider improving event link extraction")
+                logger.info("⚠️  Consider improving event link extraction")
             
             if all(ratio > 0.7 for ratio in [
                 stats["events_with_names"] / stats["total_events"],
                 stats["events_with_dates"] / stats["total_events"],
                 stats["events_with_locations"] / stats["total_events"]
             ]):
-                print("✅ Scraper quality looks good! Core fields are well extracted.")
+                logger.info("✅ Scraper quality looks good! Core fields are well extracted.")
         
         else:
-            print("❌ No events found. This could indicate:")
-            print("   - Website structure has changed")
-            print("   - Events page is currently empty")
-            print("   - Selectors need adjustment")
-            print("   - JavaScript content not loading properly")
+            logger.info("❌ No events found. This could indicate:")
+            logger.info("   - Website structure has changed")
+            logger.info("   - Events page is currently empty")
+            logger.info("   - Selectors need adjustment")
+            logger.info("   - JavaScript content not loading properly")
         
     except Exception as e:
-        print(f"❌ Test failed with error: {e}")
+        logger.error(f"❌ Test failed with error: {e}")
         import traceback
         traceback.print_exc()
         return False
     
-    print("\n" + "=" * 60)
-    print("Test completed!")
-    print("=" * 60)
+    logger.info("\n" + "=" * 60)
+    logger.info("Test completed!")
+    logger.info("=" * 60)
     return len(events) > 0 if 'events' in locals() else False
 
 
@@ -153,10 +159,10 @@ if __name__ == "__main__":
     # Test if playwright is available
     try:
         from playwright.async_api import async_playwright
-        print("✅ Playwright is available")
+        logger.info("✅ Playwright is available")
     except ImportError:
-        print("❌ Playwright not installed. Install with: pip install playwright")
-        print("   Then run: playwright install")
+        logger.info("❌ Playwright not installed. Install with: pip install playwright")
+        logger.info("   Then run: playwright install")
         sys.exit(1)
     
     # Run the test

--- a/backend/test_server.py
+++ b/backend/test_server.py
@@ -3,6 +3,13 @@
 
 import sys
 import os
+import logging
+
+from app.logging_config import configure_logging
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 try:
@@ -10,22 +17,22 @@ try:
     from app.core.config import settings
     from app.models.event import Event
     from app.routes.events import router as events_router
-    print("✅ All imports successful")
+    logger.info("✅ All imports successful")
     
     # Test configuration
-    print(f"✅ Database URL configured: {settings.database_url}")
-    print(f"✅ API will run on: {settings.api_host}:{settings.api_port}")
+    logger.info("✅ Database URL configured: %s", settings.database_url)
+    logger.info("✅ API will run on: %s:%s", settings.api_host, settings.api_port)
     
     # Test basic FastAPI app creation
     from fastapi import FastAPI
     app = FastAPI()
     app.include_router(events_router, prefix="/api")
-    print("✅ FastAPI app created successfully")
+    logger.info("✅ FastAPI app created successfully")
     
-    print("\n🎉 Backend integration test passed!")
-    print("Backend components are working correctly.")
+    logger.info("\n🎉 Backend integration test passed!")
+    logger.info("Backend components are working correctly.")
     
 except Exception as e:
-    print(f"❌ Backend test failed: {e}")
+    logger.error("❌ Backend test failed: %s", e)
     import traceback
     traceback.print_exc()


### PR DESCRIPTION
## Summary
- add shared logging configuration
- log startup/shutdown in main with logger
- sanitize auth email debug output
- convert CLI and script output to logging
- replace print statements across scraping and tasks

## Testing
- `grep -R "print(" -n backend | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_6846a32f67748328abd53200e17742f6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Replaced all print statements across the backend application and scripts with structured logging using Python’s logging module for improved message management and consistency.
  - Introduced a centralized logging configuration to standardize log formatting and levels throughout the application.

- **Chores**
  - Added a new logging configuration module to control log output and levels based on environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->