### PR TITLE
Remove console logs and update linting

### DIFF
--- a/backend/app/scraping/croatia_scraper.py
+++ b/backend/app/scraping/croatia_scraper.py
@@ -300,7 +300,6 @@ class CroatiaPlaywrightScraper:
                             for (const selector of eventSelectors) {
                                 const elements = document.querySelectorAll(selector);
                                 if (elements.length > 0) {
-                                    console.log(`Found ${elements.length} elements with selector: ${selector}`);
                                     // Filter for actual event links
                                     eventElements = Array.from(elements).filter(el => {
                                         const href = el.href || el.querySelector('a')?.href;
@@ -309,8 +308,6 @@ class CroatiaPlaywrightScraper:
                                     if (eventElements.length > 0) break;
                                 }
                             }
-                            
-                            console.log(`Processing ${eventElements.length} event elements`);
                             
                             eventElements.forEach((element, index) => {
                                 try {
@@ -405,7 +402,6 @@ class CroatiaPlaywrightScraper:
                                     
                                     // Only add if we have meaningful data
                                     if (data.title || data.link) {
-                                        console.log(`Event ${index + 1}: ${data.title || data.link}`);
                                         events.push(data);
                                     }
                                 } catch (error) {

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -25,7 +25,7 @@ export default tseslint.config(
       ],
       "@typescript-eslint/no-unused-vars": "off",
       "@typescript-eslint/no-explicit-any": "off",
-      "no-console": "warn",
+      "no-console": "error",
     },
   }
 );


### PR DESCRIPTION
## Summary
- remove leftover console.log calls from Croatia scraper
- make eslint treat console usage as an error

## Testing
- `npm run lint`
- `npm run test` *(fails: requires heavy downloads)*

------
https://chatgpt.com/codex/tasks/task_e_6847284fa4a08328ab4588b75bb2a821