### PR TITLE
Refactor permission checks

### DIFF
--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -1,0 +1,28 @@
+"""Utility helpers for permission checks."""
+
+from fastapi import HTTPException, status
+
+from ..models.user import User
+
+
+def can_user_create_events(user: User) -> bool:
+    """Return True if the user is allowed to create events."""
+    return user.venue_owner or user.venue_manager or user.is_superuser
+
+
+def require_event_creator(user: User, detail: str = "Access denied") -> None:
+    """Raise 403 if the user cannot create or manage events."""
+    if not can_user_create_events(user):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
+
+
+def require_admin(user: User, detail: str = "Admin access required") -> None:
+    """Raise 403 if the user is not an administrator."""
+    if not user.is_admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
+
+
+def require_owner_or_admin(owner_id: int, user: User, detail: str = "Access denied") -> None:
+    """Raise 403 if the user is neither the owner nor an admin."""
+    if owner_id != user.id and not user.is_admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)

--- a/backend/app/routes/booking.py
+++ b/backend/app/routes/booking.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy.orm import Session
 
 from ..core.auth import get_current_user
+from ..core.permissions import require_admin
 from ..core.booking import BookingServiceError, get_booking_service
 from ..core.database import get_db
 from ..models.booking import BookingStatus, PaymentMethod, TicketStatus
@@ -446,10 +447,7 @@ def get_booking_statistics(
     """Get booking statistics overview."""
     try:
         # Check if user has permission to view statistics (admin only)
-        if not current_user.is_admin:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required"
-            )
+        require_admin(current_user)
 
         booking_service = get_booking_service()
         stats = booking_service.get_booking_statistics(db=db, event_id=event_id)
@@ -479,10 +477,7 @@ def get_all_bookings(
     """Get all bookings (admin only)."""
     try:
         # Check admin permission
-        if not current_user.is_admin:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required"
-            )
+        require_admin(current_user)
 
         from sqlalchemy.orm import joinedload
 

--- a/backend/app/routes/performance.py
+++ b/backend/app/routes/performance.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from ..core.auth import get_current_active_user
+from ..core.permissions import require_admin
 from ..core.cache import get_cache_service
 from ..core.database import get_db, get_db_pool_status, health_check_db
 from ..core.performance import get_performance_service
@@ -49,8 +50,7 @@ def get_performance_stats(
 ):
     """Get detailed performance statistics (admin only)."""
 
-    if not current_user.is_admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
+    require_admin(current_user)
 
     performance_service = get_performance_service(db)
     stats = performance_service.get_performance_stats()
@@ -62,8 +62,7 @@ def get_performance_stats(
 def get_cache_stats(current_user: User = Depends(get_current_active_user)):
     """Get cache performance statistics (admin only)."""
 
-    if not current_user.is_admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
+    require_admin(current_user)
 
     cache_service = get_cache_service()
     return cache_service.get_stats()
@@ -79,8 +78,7 @@ def invalidate_cache_namespace(
 ):
     """Invalidate cache namespace (admin only)."""
 
-    if not current_user.is_admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
+    require_admin(current_user)
 
     cache_service = get_cache_service()
 
@@ -120,8 +118,7 @@ def flush_cache_namespace(
 ):
     """Flush entire cache namespace (admin only)."""
 
-    if not current_user.is_admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
+    require_admin(current_user)
 
     cache_service = get_cache_service()
     deleted_count = cache_service.flush_namespace(namespace)
@@ -137,8 +134,7 @@ def flush_cache_namespace(
 def get_database_pool_stats(current_user: User = Depends(get_current_active_user)):
     """Get database connection pool statistics (admin only)."""
 
-    if not current_user.is_admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
+    require_admin(current_user)
 
     pool_stats = get_db_pool_status()
 
@@ -157,8 +153,7 @@ def get_performance_summary(
 ):
     """Get performance summary (admin only)."""
 
-    if not current_user.is_admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
+    require_admin(current_user)
 
     summary = {"timestamp": datetime.now().isoformat(), "system_status": "healthy"}
 
@@ -203,8 +198,7 @@ def warm_up_cache(
 ):
     """Warm up frequently accessed cache data (admin only)."""
 
-    if not current_user.is_admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
+    require_admin(current_user)
 
     performance_service = get_performance_service(db)
     warmed_caches = []
@@ -246,8 +240,7 @@ def get_performance_recommendations(
 ):
     """Get performance optimization recommendations (admin only)."""
 
-    if not current_user.is_admin:
-        raise HTTPException(status_code=403, detail="Admin access required")
+    require_admin(current_user)
 
     recommendations = []
 

--- a/backend/app/routes/recurring_events.py
+++ b/backend/app/routes/recurring_events.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from ..core.auth import get_current_user
+from ..core.permissions import require_owner_or_admin
 from ..core.database import get_db
 from ..core.recurring_events import (
     RecurringEventsServiceError,
@@ -141,10 +142,7 @@ def get_event_series(
             )
 
         # Check if user has access (organizer or admin)
-        if series.organizer_id != current_user.id and not current_user.is_admin:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
-            )
+        require_owner_or_admin(series.organizer_id, current_user)
 
         return {
             "id": series.id,
@@ -246,10 +244,7 @@ def update_event_series(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Event series not found"
             )
 
-        if series.organizer_id != current_user.id and not current_user.is_admin:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
-            )
+        require_owner_or_admin(series.organizer_id, current_user)
 
         recurring_service = get_recurring_events_service()
 
@@ -309,10 +304,7 @@ def get_series_instances(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Event series not found"
             )
 
-        if series.organizer_id != current_user.id and not current_user.is_admin:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
-            )
+        require_owner_or_admin(series.organizer_id, current_user)
 
         recurring_service = get_recurring_events_service()
 
@@ -365,13 +357,7 @@ def modify_event_instance(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Event instance not found"
             )
 
-        if (
-            instance.series.organizer_id != current_user.id
-            and not current_user.is_admin
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
-            )
+        require_owner_or_admin(instance.series.organizer_id, current_user)
 
         recurring_service = get_recurring_events_service()
 
@@ -421,13 +407,7 @@ def cancel_event_instance(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Event instance not found"
             )
 
-        if (
-            instance.series.organizer_id != current_user.id
-            and not current_user.is_admin
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
-            )
+        require_owner_or_admin(instance.series.organizer_id, current_user)
 
         recurring_service = get_recurring_events_service()
 
@@ -473,13 +453,7 @@ def publish_event_instance(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Event instance not found"
             )
 
-        if (
-            instance.series.organizer_id != current_user.id
-            and not current_user.is_admin
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
-            )
+        require_owner_or_admin(instance.series.organizer_id, current_user)
 
         if instance.instance_status != EventInstanceStatus.SCHEDULED:
             raise HTTPException(
@@ -651,10 +625,7 @@ def get_series_statistics(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Event series not found"
             )
 
-        if series.organizer_id != current_user.id and not current_user.is_admin:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
-            )
+        require_owner_or_admin(series.organizer_id, current_user)
 
         recurring_service = get_recurring_events_service()
 

--- a/backend/app/routes/user_events.py
+++ b/backend/app/routes/user_events.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field, validator
 from sqlalchemy.orm import Session, joinedload
 
 from ..core.auth import get_current_superuser, get_current_user
+from ..core.permissions import require_event_creator
 from ..core.database import get_db
 from ..models.booking import TicketType
 from ..models.category import EventCategory
@@ -95,11 +96,6 @@ class EventApprovalUpdate(BaseModel):
 
 
 # Helper functions
-def can_user_create_events(user: User) -> bool:
-    """Check if user can create events"""
-    return user.venue_owner or user.venue_manager or user.is_superuser
-
-
 def generate_event_slug(title: str, event_id: int) -> str:
     """Generate a URL-friendly slug for the event"""
     import re
@@ -118,12 +114,10 @@ def create_user_event(
 ):
     """Create a new user-generated event."""
     try:
-        # Check if user can create events
-        if not can_user_create_events(current_user):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="You need to be a venue owner or manager to create events. Please contact support to upgrade your account.",
-            )
+        require_event_creator(
+            current_user,
+            "You need to be a venue owner or manager to create events. Please contact support to upgrade your account.",
+        )
 
         # Validate category exists
         category = (
@@ -646,10 +640,7 @@ def get_organizer_stats(
 ):
     """Get statistics for the current organizer."""
     try:
-        if not can_user_create_events(current_user):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
-            )
+        require_event_creator(current_user)
 
         # Get event statistics
         total_events = (
@@ -735,10 +726,7 @@ def get_revenue_trends(
 ):
     """Get revenue trends over time for the organizer."""
     try:
-        if not can_user_create_events(current_user):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
-            )
+        require_event_creator(current_user)
 
         from sqlalchemy import extract, func
 
@@ -807,10 +795,7 @@ def get_event_performance(
 ):
     """Get performance breakdown by event for the organizer."""
     try:
-        if not can_user_create_events(current_user):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
-            )
+        require_event_creator(current_user)
 
         from sqlalchemy import func
 
@@ -876,10 +861,7 @@ def get_ticket_type_analytics(
 ):
     """Get analytics breakdown by ticket types for the organizer."""
     try:
-        if not can_user_create_events(current_user):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
-            )
+        require_event_creator(current_user)
 
         from sqlalchemy import func
 
@@ -942,10 +924,7 @@ def get_booking_conversion_metrics(
 ):
     """Get booking conversion metrics for the organizer."""
     try:
-        if not can_user_create_events(current_user):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
-            )
+        require_event_creator(current_user)
 
         from sqlalchemy import func
 
@@ -1018,10 +997,7 @@ def get_geographic_revenue(
 ):
     """Get revenue distribution by location for the organizer."""
     try:
-        if not can_user_create_events(current_user):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
-            )
+        require_event_creator(current_user)
 
         from sqlalchemy import func
 


### PR DESCRIPTION
## Summary
- centralize permission logic in `core/permissions`
- reuse permission helpers across booking, recurring events, performance and user events

## Testing
- `npm run test` *(fails: pydantic ValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_68473ed595c883289083d0687054b745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Centralized permission and access control checks across multiple routes, replacing repeated inline logic with reusable permission functions for admin, event creator, and owner/admin roles.
	- Improved consistency and maintainability of permission enforcement in event, booking, performance, and recurring event endpoints.
- **Chores**
	- Removed redundant helper functions and consolidated error handling for unauthorized access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->