### PR TITLE
Add VisitOpatija scraper

### DIFF
--- a/backend/app/routes/scraping.py
+++ b/backend/app/routes/scraping.py
@@ -15,6 +15,7 @@ from ..scraping.enhanced_scraper import (
 from ..scraping.entrio_scraper import scrape_entrio_events
 from ..scraping.infozagreb_scraper import scrape_infozagreb_events
 from ..scraping.ulaznice_scraper import scrape_ulaznice_events
+from ..scraping.visitopatija_scraper import scrape_visitopatija_events
 
 router = APIRouter(prefix="/scraping", tags=["scraping"])
 
@@ -39,7 +40,7 @@ class EnhancedScrapeRequest(BaseModel):
 
 
 class SingleSourceRequest(BaseModel):
-    source: str  # "entrio", "croatia" or "ulaznice" or "info zagreb"
+    source: str  # "entrio", "croatia", "ulaznice", "infozagreb", or "visitopatija"
 
     max_pages: int = 5
     quality_threshold: float = 60.0
@@ -246,6 +247,44 @@ async def quick_scrape_infozagreb(
         raise HTTPException(status_code=500, detail=f"InfoZagreb scraping failed: {str(e)}")
 
 
+@router.post("/visitopatija", response_model=ScrapeResponse)
+async def scrape_visitopatija(request: ScrapeRequest, background_tasks: BackgroundTasks):
+    """Trigger VisitOpatija.com event scraping."""
+    try:
+        if request.max_pages <= 2:
+            result = await scrape_visitopatija_events(max_pages=request.max_pages)
+            return ScrapeResponse(**result)
+
+        import uuid
+
+        task_id = str(uuid.uuid4())
+
+        async def run_visit_task():
+            return await scrape_visitopatija_events(max_pages=request.max_pages)
+
+        background_tasks.add_task(run_visit_task)
+
+        return ScrapeResponse(
+            status="accepted",
+            message=f"VisitOpatija.com scraping task started in background for {request.max_pages} pages",
+            task_id=task_id,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to start VisitOpatija scraping: {str(e)}")
+
+
+@router.get("/visitopatija/quick", response_model=ScrapeResponse)
+async def quick_scrape_visitopatija(
+    max_pages: int = Query(1, ge=1, le=3, description="Number of pages to scrape (1-3 for quick scraping)")
+):
+    """Quick VisitOpatija.com scraping."""
+    try:
+        result = await scrape_visitopatija_events(max_pages=max_pages)
+        return ScrapeResponse(**result)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"VisitOpatija scraping failed: {str(e)}")
+
+
 @router.post("/all", response_model=ScrapeResponse)
 async def scrape_all_sites(request: ScrapeRequest, background_tasks: BackgroundTasks):
     """
@@ -282,6 +321,12 @@ async def scrape_all_sites(request: ScrapeRequest, background_tasks: BackgroundT
                     max_pages=request.max_pages
                 )
                 results.append(("Ulaznice.hr", ulaznice_result))
+
+                # Scrape VisitOpatija.com
+                visit_result = await scrape_visitopatija_events(
+                    max_pages=request.max_pages
+                )
+                results.append(("VisitOpatija.com", visit_result))
 
                 # Combine results
                 total_scraped = sum(
@@ -341,7 +386,7 @@ async def scraping_status():
     return {
         "status": "operational",
         "config": config,
-        "supported_sites": ["entrio.hr", "croatia.hr", "ulaznice.hr", "infozagreb.hr"],
+        "supported_sites": ["entrio.hr", "croatia.hr", "ulaznice.hr", "infozagreb.hr", "visitopatija.com"],
         "endpoints": {
             "POST /scraping/entrio": "Entrio.hr full scraping with background processing",
             "GET /scraping/entrio/quick": "Entrio.hr quick scraping (1-3 pages)",
@@ -351,6 +396,8 @@ async def scraping_status():
             "GET /scraping/infozagreb/quick": "InfoZagreb.hr quick scraping (1-3 pages)",
             "POST /scraping/ulaznice": "Ulaznice.hr full scraping with background processing",
             "GET /scraping/ulaznice/quick": "Ulaznice.hr quick scraping (1-3 pages)",
+            "POST /scraping/visitopatija": "VisitOpatija.com full scraping with background processing",
+            "GET /scraping/visitopatija/quick": "VisitOpatija.com quick scraping (1-3 pages)",
             "POST /scraping/all": "Scrape all supported sites",
             "POST /scraping/enhanced/pipeline": "Enhanced scraping pipeline with quality validation",
             "POST /scraping/enhanced/single": "Enhanced single source scraping",
@@ -460,10 +507,10 @@ async def enhanced_single_source_scraping(
     - Detailed performance metrics
     """
     try:
-        if request.source.lower() not in ["entrio", "croatia", "ulaznice", "infozagreb"]:
+        if (request.source.lower() not in ["entrio", "croatia", "ulaznice", "infozagreb", "visitopatija"]):
             raise HTTPException(
                 status_code=400,
-                detail="Source must be 'entrio', 'croatia', 'ulaznice' or 'infozagreb'"
+                detail="Source must be 'entrio', 'croatia', 'ulaznice', 'infozagreb' or 'visitopatija'"
             )
 
         import uuid
@@ -545,10 +592,10 @@ async def enhanced_scraping_demo(
     - Detailed quality report
     """
     try:
-        if source.lower() not in ["entrio", "croatia", "ulaznice"]:
+        if source.lower() not in ["entrio", "croatia", "ulaznice", "infozagreb", "visitopatija"]:
             raise HTTPException(
                 status_code=400,
-                detail="Source must be 'entrio', 'croatia' or 'ulaznice'",
+                detail="Source must be 'entrio', 'croatia', 'ulaznice', 'infozagreb' or 'visitopatija'",
             )
 
         logger.info(f"Starting enhanced scraping demo for {source} ({max_pages} pages)")

--- a/backend/app/scraping/visitopatija_scraper.py
+++ b/backend/app/scraping/visitopatija_scraper.py
@@ -1,0 +1,362 @@
+"""Scraper for VisitOpatija.com events."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from datetime import date
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import urljoin
+
+import httpx
+from bs4 import BeautifulSoup, Tag
+from sqlalchemy.dialects.postgresql import insert
+
+from ..core.database import SessionLocal
+from ..models.event import Event
+from ..models.schemas import EventCreate
+
+# BrightData configuration (same as other scrapers)
+USER = os.getenv("BRIGHTDATA_USER", "demo_user")
+PASSWORD = os.getenv("BRIGHTDATA_PASSWORD", "demo_password")
+BRIGHTDATA_HOST_RES = "brd.superproxy.io"
+BRIGHTDATA_PORT = int(os.getenv("BRIGHTDATA_PORT", 22225))
+SCRAPING_BROWSER_EP = f"https://brd.superproxy.io:{BRIGHTDATA_PORT}"
+PROXY = f"http://{USER}:{PASSWORD}@{BRIGHTDATA_HOST_RES}:{BRIGHTDATA_PORT}"
+
+USE_SB = os.getenv("USE_SCRAPING_BROWSER", "0") == "1"
+USE_PROXY = os.getenv("USE_PROXY", "0") == "1"
+
+HEADERS = {
+    "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 ScraperBot/1.0",
+}
+
+BASE_URL = "https://www.visitopatija.com"
+EVENTS_URL = f"{BASE_URL}/en/events"
+
+
+class VisitOpatijaEventDataTransformer:
+    """Utility class for cleaning and converting event data."""
+
+    @staticmethod
+    def parse_date(date_str: str) -> Optional[date]:
+        if not date_str:
+            return None
+
+        date_str = date_str.strip()
+        patterns = [
+            r"(\d{1,2})\.(\d{1,2})\.(\d{4})",
+            r"(\d{4})-(\d{1,2})-(\d{1,2})",
+            r"(\d{1,2})/(\d{1,2})/(\d{4})",
+            r"(\d{1,2})\s+(\w+)\s*(\d{4})",
+        ]
+
+        cro_months = {
+            "siječnja": 1,
+            "veljače": 2,
+            "ožujka": 3,
+            "travnja": 4,
+            "svibnja": 5,
+            "lipnja": 6,
+            "srpnja": 7,
+            "kolovoza": 8,
+            "rujna": 9,
+            "listopada": 10,
+            "studenoga": 11,
+            "prosinca": 12,
+        }
+
+        for pattern in patterns:
+            m = re.search(pattern, date_str, re.IGNORECASE)
+            if m:
+                try:
+                    if pattern.startswith("(\\d{1,2})" ):
+                        day, month, year = m.groups()
+                        if month.isdigit():
+                            return date(int(year), int(month), int(day))
+                        month_num = cro_months.get(month.lower(), 1)
+                        return date(int(year), month_num, int(day))
+                    elif pattern.startswith("(\\d{4})"):
+                        year, month, day = m.groups()
+                        return date(int(year), int(month), int(day))
+                except (ValueError, TypeError):
+                    continue
+
+        year_match = re.search(r"(\d{4})", date_str)
+        if year_match:
+            try:
+                return date(int(year_match.group(1)), 1, 1)
+            except ValueError:
+                pass
+        return None
+
+    @staticmethod
+    def parse_time(time_str: str) -> str:
+        if not time_str:
+            return "20:00"
+        m = re.search(r"(\d{1,2}):(\d{2})", time_str)
+        if m:
+            hour, minute = m.groups()
+            return f"{int(hour):02d}:{minute}"
+        m = re.search(r"(\d{1,2})h", time_str)
+        if m:
+            hour = m.group(1)
+            return f"{int(hour):02d}:00"
+        return "20:00"
+
+    @staticmethod
+    def clean_text(text: str) -> str:
+        return " ".join(text.split()) if text else ""
+
+    @classmethod
+    def transform(cls, data: Dict) -> Optional[EventCreate]:
+        try:
+            name = cls.clean_text(data.get("title", ""))
+            if not name or len(name) < 3:
+                return None
+            location = cls.clean_text(data.get("location", "Opatija"))
+            description = cls.clean_text(data.get("description", ""))
+            price = cls.clean_text(data.get("price", ""))
+
+            date_str = data.get("date", "")
+            parsed_date = cls.parse_date(date_str)
+            if not parsed_date:
+                return None
+
+            time_str = data.get("time", "")
+            parsed_time = cls.parse_time(time_str)
+
+            image = data.get("image")
+            if image and not image.startswith("http"):
+                image = urljoin(BASE_URL, image)
+
+            link = data.get("link")
+            if link and not link.startswith("http"):
+                link = urljoin(BASE_URL, link)
+
+            return EventCreate(
+                name=name,
+                time=parsed_time,
+                date=parsed_date,
+                location=location or "Opatija",
+                description=description or f"Event: {name}",
+                price=price or "Check website",
+                image=image,
+                link=link,
+            )
+        except Exception:
+            return None
+
+
+class VisitOpatijaRequestsScraper:
+    """Scraper using httpx and BeautifulSoup."""
+
+    def __init__(self) -> None:
+        self.client = httpx.AsyncClient(headers=HEADERS)
+
+    async def fetch(self, url: str) -> httpx.Response:
+        try:
+            if USE_SB and USE_PROXY:
+                params = {"url": url}
+                async with httpx.AsyncClient(
+                    headers=HEADERS, auth=(USER, PASSWORD), verify=False
+                ) as client:
+                    resp = await client.get(SCRAPING_BROWSER_EP, params=params, timeout=30)
+            elif USE_PROXY:
+                async with httpx.AsyncClient(
+                    headers=HEADERS,
+                    proxies={"http": PROXY, "https": PROXY},
+                    verify=False,
+                ) as client:
+                    resp = await client.get(url, timeout=30)
+            else:
+                async with httpx.AsyncClient(headers=HEADERS) as client:
+                    resp = await client.get(url, timeout=30)
+            resp.raise_for_status()
+            return resp
+        except httpx.HTTPError as e:
+            print(f"Request failed for {url}: {e}")
+            raise
+
+    async def parse_event_detail(self, url: str) -> Dict:
+        resp = await self.fetch(url)
+        soup = BeautifulSoup(resp.text, "html.parser")
+        data: Dict[str, str] = {}
+
+        title_el = soup.select_one("h1")
+        if title_el:
+            data["title"] = title_el.get_text(strip=True)
+
+        desc_el = soup.select_one(".description, .text, article")
+        if desc_el:
+            data["description"] = desc_el.get_text(separator=" ", strip=True)
+
+        date_el = soup.find(string=re.compile(r"\d{4}"))
+        if date_el:
+            data["date"] = date_el.strip()
+
+        time_el = soup.find(string=re.compile(r"\d{1,2}:\d{2}"))
+        if time_el:
+            data["time"] = time_el.strip()
+
+        img_el = soup.select_one("img[src]")
+        if img_el:
+            data["image"] = img_el.get("src")
+
+        loc_el = soup.select_one(".location, .venue, .place")
+        if loc_el:
+            data["location"] = loc_el.get_text(strip=True)
+
+        price_el = soup.find(string=re.compile(r"\d"))
+        if price_el:
+            data["price"] = price_el.strip()
+
+        return data
+
+    def parse_listing_element(self, el: Tag) -> Dict:
+        data: Dict[str, str] = {}
+        link_el = el.select_one("a")
+        if link_el and link_el.get("href"):
+            data["link"] = urljoin(BASE_URL, link_el.get("href"))
+            if link_el.get_text(strip=True):
+                data["title"] = link_el.get_text(strip=True)
+
+        date_el = el.select_one(".date, time")
+        if date_el and date_el.get_text(strip=True):
+            data["date"] = date_el.get_text(strip=True)
+
+        img_el = el.select_one("img")
+        if img_el and img_el.get("src"):
+            data["image"] = img_el.get("src")
+
+        loc_el = el.select_one(".location, .venue, .place")
+        if loc_el:
+            data["location"] = loc_el.get_text(strip=True)
+
+        return data
+
+    async def scrape_events_page(self, url: str) -> Tuple[List[Dict], Optional[str]]:
+        resp = await self.fetch(url)
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+        events: List[Dict] = []
+        containers: List[Tag] = []
+        selectors = [
+            "li.event-item",
+            "div.event-item",
+            "article",
+            ".events-list li",
+            "[class*='event']",
+        ]
+        for sel in selectors:
+            found = soup.select(sel)
+            if found:
+                containers = found
+                break
+
+        for el in containers:
+            if isinstance(el, Tag):
+                data = self.parse_listing_element(el)
+                link = data.get("link")
+                if link:
+                    try:
+                        detail = await self.parse_event_detail(link)
+                        data.update({k: v for k, v in detail.items() if v})
+                    except Exception:
+                        pass
+                if data:
+                    events.append(data)
+
+        next_url = None
+        next_link = soup.select_one('a[rel="next"], .pagination-next a, a.next')
+        if next_link and next_link.get("href"):
+            next_url = urljoin(url, next_link.get("href"))
+
+        return events, next_url
+
+    async def scrape_all_events(self, max_pages: int = 5) -> List[Dict]:
+        all_events: List[Dict] = []
+        current_url = EVENTS_URL
+        page = 0
+        while current_url and page < max_pages:
+            page += 1
+            try:
+                events, next_url = await self.scrape_events_page(current_url)
+                all_events.extend(events)
+                if not next_url or not events:
+                    break
+                current_url = next_url
+                await asyncio.sleep(1)
+            except Exception as e:
+                print(f"Failed to scrape {current_url}: {e}")
+                break
+        return all_events
+
+    async def close(self) -> None:
+        await self.client.aclose()
+
+
+class VisitOpatijaScraper:
+    """High-level scraper for VisitOpatija.com."""
+
+    def __init__(self) -> None:
+        self.requests_scraper = VisitOpatijaRequestsScraper()
+        self.transformer = VisitOpatijaEventDataTransformer()
+
+    async def scrape_events(self, max_pages: int = 5) -> List[EventCreate]:
+        raw = await self.requests_scraper.scrape_all_events(max_pages=max_pages)
+        events: List[EventCreate] = []
+        for item in raw:
+            event = self.transformer.transform(item)
+            if event:
+                events.append(event)
+        await self.requests_scraper.close()
+        return events
+
+    def save_events_to_database(self, events: List[EventCreate]) -> int:
+        if not events:
+            return 0
+        db = SessionLocal()
+        try:
+            event_dicts = [e.model_dump() for e in events]
+            pairs = [(e["name"], e["date"]) for e in event_dicts]
+            existing = db.execute(
+                insert(Event)
+                .returning(Event.name, Event.date)
+                .on_conflict_do_nothing()
+            ).fetchall()
+            existing_pairs = set(existing)
+            to_insert = [e for e in event_dicts if (e["name"], e["date"]) not in existing_pairs]
+            if to_insert:
+                stmt = insert(Event).values(to_insert)
+                stmt = stmt.on_conflict_do_nothing(index_elements=["name", "date"])
+                db.execute(stmt)
+                db.commit()
+                return len(to_insert)
+            db.commit()
+            return 0
+        except Exception as e:
+            print(f"Error saving VisitOpatija events: {e}")
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+
+async def scrape_visitopatija_events(max_pages: int = 5) -> Dict:
+    """Scrape VisitOpatija events and save to database."""
+    scraper = VisitOpatijaScraper()
+    try:
+        events = await scraper.scrape_events(max_pages=max_pages)
+        saved = scraper.save_events_to_database(events)
+        return {
+            "status": "success",
+            "scraped_events": len(events),
+            "saved_events": saved,
+            "message": f"Scraped {len(events)} events from VisitOpatija.com, saved {saved} new events",
+        }
+    except Exception as e:
+        return {"status": "error", "message": f"VisitOpatija scraping failed: {e}"}
+

--- a/backend/scripts/test_visitopatija_scraper.py
+++ b/backend/scripts/test_visitopatija_scraper.py
@@ -1,0 +1,54 @@
+"""Test script for VisitOpatija.com scraper."""
+
+import asyncio
+import sys
+import os
+import json
+from datetime import datetime
+import pytest
+
+# Add parent directory to import app modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from app.scraping.visitopatija_scraper import VisitOpatijaScraper
+
+
+@pytest.mark.asyncio
+async def test_visitopatija_scraper():
+    """Basic test for the VisitOpatija scraper."""
+    print("=" * 60)
+    print("VisitOpatija.com Scraper Test")
+    print("=" * 60)
+
+    scraper = VisitOpatijaScraper()
+
+    try:
+        print("Starting VisitOpatija scraper test (max 1 page)...")
+        events = await scraper.scrape_events(max_pages=1)
+        print(f"\n✅ Scraping completed: {len(events)} events")
+
+        assert isinstance(events, list)
+
+        if events:
+            first = events[0]
+            print("Sample event:")
+            print(f"  Name: {first.name}")
+            print(f"  Date: {first.date}")
+            print(f"  Location: {first.location}")
+            print(f"  Link: {first.link}")
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"visitopatija_scraper_test_{timestamp}.json"
+        with open(filename, "w", encoding="utf-8") as f:
+            json.dump([e.model_dump() for e in events[:5]], f, ensure_ascii=False, indent=2)
+        print(f"\nSaved sample data to {filename}")
+    except Exception as e:
+        print(f"Scraper failed: {e}")
+        return False
+
+    return True
+
+
+if __name__ == "__main__":
+    success = asyncio.run(test_visitopatija_scraper())
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary
- add scraper for VisitOpatija.com with Bright Data support
- expose VisitOpatija routes in the scraping API
- allow VisitOpatija as a source in enhanced pipelines
- include a basic scraper test script

## Testing
- `npm run test:backend` *(fails: ValidationError due to missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6849e59e6d848328a615fe774c3b547a