### PR TITLE
Add VisitVarazdin scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ The backend includes an integrated web scraping system that automatically collec
 - **Entrio.hr** - Croatia's leading event ticketing platform
 - **Croatia.hr** - Official Croatian tourism events portal
 - **InfoZagreb.hr** - Zagreb tourist board event listings
+- **VisitVarazdin.hr** - Varaždin tourist board events
 
 ### Features
 - **Dual Scraping Approach**: Uses both requests/BeautifulSoup and Playwright for maximum compatibility
@@ -225,6 +226,9 @@ curl -X GET "http://localhost:8000/api/scraping/croatia/quick?max_pages=2"
 # Quick scraping from InfoZagreb.hr (1-3 pages)
 curl -X GET "http://localhost:8000/api/scraping/infozagreb/quick?max_pages=2"
 
+# Quick scraping from VisitVarazdin.hr (1-3 pages)
+curl -X GET "http://localhost:8000/api/scraping/visitvarazdin/quick?max_pages=2"
+
 # Full scraping from specific site (background task)
 curl -X POST "http://localhost:8000/api/scraping/entrio" \
   -H "Content-Type: application/json" \
@@ -232,6 +236,11 @@ curl -X POST "http://localhost:8000/api/scraping/entrio" \
 
 # Full scraping from InfoZagreb.hr
 curl -X POST "http://localhost:8000/api/scraping/infozagreb" \
+  -H "Content-Type: application/json" \
+  -d '{"max_pages": 5}'
+
+# Full scraping from VisitVarazdin.hr
+curl -X POST "http://localhost:8000/api/scraping/visitvarazdin" \
   -H "Content-Type: application/json" \
   -d '{"max_pages": 5}'
 
@@ -253,7 +262,7 @@ ENABLE_SCHEDULER=true
 **Schedules:**
 - **Production**: Daily at 02:00 (10 pages per site)
 - **Development**: Hourly (2 pages per site)
-- **Sites**: Entrio.hr, Croatia.hr and InfoZagreb.hr
+- **Sites**: Entrio.hr, Croatia.hr, InfoZagreb.hr and VisitVarazdin.hr
 
 ### Configuration
 
@@ -341,6 +350,8 @@ The backend provides RESTful API endpoints:
 - `GET /api/scraping/croatia/quick` - Quick Croatia.hr scraping (1-3 pages)
 - `POST /api/scraping/infozagreb` - Trigger full InfoZagreb.hr scraping
 - `GET /api/scraping/infozagreb/quick` - Quick InfoZagreb.hr scraping (1-3 pages)
+- `POST /api/scraping/visitvarazdin` - Trigger full VisitVarazdin.hr scraping
+- `GET /api/scraping/visitvarazdin/quick` - Quick VisitVarazdin.hr scraping (1-3 pages)
 - `POST /api/scraping/all` - Scrape from all supported sites
 - `GET /api/scraping/status` - Get scraping system status
 

--- a/backend/app/routes/scraping.py
+++ b/backend/app/routes/scraping.py
@@ -15,6 +15,7 @@ from ..scraping.enhanced_scraper import (
 from ..scraping.entrio_scraper import scrape_entrio_events
 from ..scraping.infozagreb_scraper import scrape_infozagreb_events
 from ..scraping.ulaznice_scraper import scrape_ulaznice_events
+from ..scraping.visitvarazdin_scraper import scrape_visitvarazdin_events
 
 router = APIRouter(prefix="/scraping", tags=["scraping"])
 
@@ -39,7 +40,7 @@ class EnhancedScrapeRequest(BaseModel):
 
 
 class SingleSourceRequest(BaseModel):
-    source: str  # "entrio", "croatia" or "ulaznice" or "info zagreb"
+    source: str  # "entrio", "croatia", "ulaznice", "infozagreb" or "visitvarazdin"
 
     max_pages: int = 5
     quality_threshold: float = 60.0
@@ -234,6 +235,33 @@ async def scrape_infozagreb(request: ScrapeRequest, background_tasks: Background
         raise HTTPException(status_code=500, detail=f"Failed to start InfoZagreb scraping: {str(e)}")
 
 
+@router.post("/visitvarazdin", response_model=ScrapeResponse)
+async def scrape_visitvarazdin(request: ScrapeRequest, background_tasks: BackgroundTasks):
+    """Trigger VisitVarazdin.hr event scraping."""
+    try:
+        if request.max_pages <= 2:
+            result = await scrape_visitvarazdin_events(max_pages=request.max_pages)
+            return ScrapeResponse(**result)
+
+        import uuid
+
+        task_id = str(uuid.uuid4())
+
+        async def run_vz_scrape():
+            return await scrape_visitvarazdin_events(max_pages=request.max_pages)
+
+        background_tasks.add_task(run_vz_scrape)
+
+        return ScrapeResponse(
+            status="accepted",
+            message=f"VisitVarazdin scraping task started in background for {request.max_pages} pages",
+            task_id=task_id,
+        )
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to start VisitVarazdin scraping: {str(e)}")
+
+
 @router.get("/infozagreb/quick", response_model=ScrapeResponse)
 async def quick_scrape_infozagreb(
     max_pages: int = Query(1, ge=1, le=3, description="Number of pages to scrape (1-3 for quick scraping)")
@@ -244,6 +272,18 @@ async def quick_scrape_infozagreb(
         return ScrapeResponse(**result)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"InfoZagreb scraping failed: {str(e)}")
+
+
+@router.get("/visitvarazdin/quick", response_model=ScrapeResponse)
+async def quick_scrape_visitvarazdin(
+    max_pages: int = Query(1, ge=1, le=3, description="Number of pages to scrape (1-3 for quick scraping)")
+):
+    """Quick VisitVarazdin.hr scraping."""
+    try:
+        result = await scrape_visitvarazdin_events(max_pages=max_pages)
+        return ScrapeResponse(**result)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"VisitVarazdin scraping failed: {str(e)}")
 
 
 @router.post("/all", response_model=ScrapeResponse)
@@ -276,6 +316,12 @@ async def scrape_all_sites(request: ScrapeRequest, background_tasks: BackgroundT
                     max_pages=request.max_pages
                 )
                 results.append(("InfoZagreb.hr", info_result))
+
+                # Scrape VisitVarazdin.hr
+                vz_result = await scrape_visitvarazdin_events(
+                    max_pages=request.max_pages
+                )
+                results.append(("VisitVarazdin.hr", vz_result))
 
                 # Scrape Ulaznice.hr
                 ulaznice_result = await scrape_ulaznice_events(
@@ -341,7 +387,13 @@ async def scraping_status():
     return {
         "status": "operational",
         "config": config,
-        "supported_sites": ["entrio.hr", "croatia.hr", "ulaznice.hr", "infozagreb.hr"],
+        "supported_sites": [
+            "entrio.hr",
+            "croatia.hr",
+            "ulaznice.hr",
+            "infozagreb.hr",
+            "visitvarazdin.hr",
+        ],
         "endpoints": {
             "POST /scraping/entrio": "Entrio.hr full scraping with background processing",
             "GET /scraping/entrio/quick": "Entrio.hr quick scraping (1-3 pages)",
@@ -349,6 +401,8 @@ async def scraping_status():
             "GET /scraping/croatia/quick": "Croatia.hr quick scraping (1-3 pages)",
             "POST /scraping/infozagreb": "InfoZagreb.hr full scraping with background processing",
             "GET /scraping/infozagreb/quick": "InfoZagreb.hr quick scraping (1-3 pages)",
+            "POST /scraping/visitvarazdin": "VisitVarazdin.hr full scraping with background processing",
+            "GET /scraping/visitvarazdin/quick": "VisitVarazdin.hr quick scraping (1-3 pages)",
             "POST /scraping/ulaznice": "Ulaznice.hr full scraping with background processing",
             "GET /scraping/ulaznice/quick": "Ulaznice.hr quick scraping (1-3 pages)",
             "POST /scraping/all": "Scrape all supported sites",
@@ -460,10 +514,10 @@ async def enhanced_single_source_scraping(
     - Detailed performance metrics
     """
     try:
-        if request.source.lower() not in ["entrio", "croatia", "ulaznice", "infozagreb"]:
+        if request.source.lower() not in ["entrio", "croatia", "ulaznice", "infozagreb", "visitvarazdin"]:
             raise HTTPException(
                 status_code=400,
-                detail="Source must be 'entrio', 'croatia', 'ulaznice' or 'infozagreb'"
+                detail="Source must be 'entrio', 'croatia', 'ulaznice', 'infozagreb' or 'visitvarazdin'"
             )
 
         import uuid
@@ -545,10 +599,10 @@ async def enhanced_scraping_demo(
     - Detailed quality report
     """
     try:
-        if source.lower() not in ["entrio", "croatia", "ulaznice"]:
+        if source.lower() not in ["entrio", "croatia", "ulaznice", "infozagreb", "visitvarazdin"]:
             raise HTTPException(
                 status_code=400,
-                detail="Source must be 'entrio', 'croatia' or 'ulaznice'",
+                detail="Source must be 'entrio', 'croatia', 'ulaznice', 'infozagreb' or 'visitvarazdin'",
             )
 
         logger.info(f"Starting enhanced scraping demo for {source} ({max_pages} pages)")

--- a/backend/app/scraping/enhanced_scraper.py
+++ b/backend/app/scraping/enhanced_scraper.py
@@ -16,6 +16,7 @@ from .croatia_scraper import CroatiaScraper
 from .entrio_scraper import EntrioScraper
 from .infozagreb_scraper import InfoZagrebScraper
 from .ulaznice_scraper import UlazniceScraper
+from .visitvarazdin_scraper import VisitVarazdinScraper
 
 
 class EnhancedScrapingPipeline:
@@ -29,6 +30,7 @@ class EnhancedScrapingPipeline:
         self.entrio_scraper = EntrioScraper()
         self.croatia_scraper = CroatiaScraper()
         self.infozagreb_scraper = InfoZagrebScraper()
+        self.visitvarazdin_scraper = VisitVarazdinScraper()
         self.ulaznice_scraper = UlazniceScraper()
 
     async def scrape_all_sources(self, max_pages_per_source: int = 5) -> Dict[str, Any]:
@@ -50,6 +52,7 @@ class EnhancedScrapingPipeline:
             ("entrio.hr", self.entrio_scraper, max_pages_per_source),
             ("croatia.hr", self.croatia_scraper, max_pages_per_source),
             ("infozagreb.hr", self.infozagreb_scraper, max_pages_per_source),
+            ("visitvarazdin.hr", self.visitvarazdin_scraper, max_pages_per_source),
             ("ulaznice.hr", self.ulaznice_scraper, max_pages_per_source),
         ]
 
@@ -232,6 +235,8 @@ class EnhancedScrapingPipeline:
             scraper = self.croatia_scraper
         elif source.lower() == "infozagreb":
             scraper = self.infozagreb_scraper
+        elif source.lower() == "visitvarazdin":
+            scraper = self.visitvarazdin_scraper
         elif source.lower() == "ulaznice":
             scraper = self.ulaznice_scraper
         else:

--- a/backend/app/scraping/visitvarazdin_scraper.py
+++ b/backend/app/scraping/visitvarazdin_scraper.py
@@ -1,0 +1,340 @@
+"""VisitVarazdin.hr event scraper with Bright Data support."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from datetime import date
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import urljoin
+
+import httpx
+from bs4 import BeautifulSoup, Tag
+
+from ..models.schemas import EventCreate
+
+# Bright Data configuration (same as other scrapers)
+USER = os.getenv("BRIGHTDATA_USER", "demo_user")
+PASSWORD = os.getenv("BRIGHTDATA_PASSWORD", "demo_password")
+BRIGHTDATA_HOST_RES = "brd.superproxy.io"
+BRIGHTDATA_PORT = int(os.getenv("BRIGHTDATA_PORT", 22225))
+SCRAPING_BROWSER_EP = f"https://brd.superproxy.io:{BRIGHTDATA_PORT}"
+PROXY = f"http://{USER}:{PASSWORD}@{BRIGHTDATA_HOST_RES}:{BRIGHTDATA_PORT}"
+
+USE_SB = os.getenv("USE_SCRAPING_BROWSER", "0") == "1"
+USE_PROXY = os.getenv("USE_PROXY", "0") == "1"
+USE_PLAYWRIGHT = os.getenv("USE_PLAYWRIGHT", "1") == "1"
+
+HEADERS = {
+    "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 ScraperBot/1.0",
+}
+
+BASE_URL = "https://visitvarazdin.hr"
+EVENTS_URL = f"{BASE_URL}/events"
+
+
+class VisitVarazdinEventDataTransformer:
+    """Transform raw VisitVarazdin event data to :class:`EventCreate`."""
+
+    CRO_MONTHS = {
+        "siječnja": 1,
+        "veljače": 2,
+        "ožujka": 3,
+        "travnja": 4,
+        "svibnja": 5,
+        "lipnja": 6,
+        "srpnja": 7,
+        "kolovoza": 8,
+        "rujna": 9,
+        "listopada": 10,
+        "studenoga": 11,
+        "prosinca": 12,
+    }
+
+    @staticmethod
+    def parse_date(date_str: str) -> Optional[date]:
+        if not date_str:
+            return None
+        date_str = date_str.strip()
+        patterns = [
+            r"(\d{1,2})\.(\d{1,2})\.(\d{4})",
+            r"(\d{4})-(\d{1,2})-(\d{1,2})",
+            r"(\d{1,2})\s+(\w+)\s*(\d{4})",
+        ]
+        for pattern in patterns:
+            m = re.search(pattern, date_str, re.IGNORECASE)
+            if m:
+                try:
+                    if pattern.startswith("("):
+                        day, month, year = m.groups()
+                        if month.isdigit():
+                            return date(int(year), int(month), int(day))
+                        month_num = VisitVarazdinEventDataTransformer.CRO_MONTHS.get(month.lower())
+                        if month_num:
+                            return date(int(year), month_num, int(day))
+                    elif pattern.startswith("(\\d{4})"):
+                        year, month, day = m.groups()
+                        return date(int(year), int(month), int(day))
+                except (ValueError, TypeError):
+                    continue
+        year_match = re.search(r"(\d{4})", date_str)
+        if year_match:
+            try:
+                return date(int(year_match.group(1)), 1, 1)
+            except ValueError:
+                pass
+        return None
+
+    @staticmethod
+    def parse_time(time_str: str) -> str:
+        if not time_str:
+            return "20:00"
+        m = re.search(r"(\d{1,2}):(\d{2})", time_str)
+        if m:
+            hour, minute = m.groups()
+            return f"{int(hour):02d}:{minute}"
+        m = re.search(r"(\d{1,2})h", time_str)
+        if m:
+            hour = m.group(1)
+            return f"{int(hour):02d}:00"
+        return "20:00"
+
+    @staticmethod
+    def clean_text(text: str) -> str:
+        return " ".join(text.split()) if text else ""
+
+    @classmethod
+    def transform(cls, data: Dict) -> Optional[EventCreate]:
+        try:
+            name = cls.clean_text(data.get("title", ""))
+            location = cls.clean_text(data.get("location", "Varaždin"))
+            description = cls.clean_text(data.get("description", ""))
+            price = cls.clean_text(data.get("price", ""))
+
+            date_str = data.get("date", "")
+            parsed_date = cls.parse_date(date_str)
+            if not parsed_date:
+                return None
+
+            time_str = data.get("time", "")
+            parsed_time = cls.parse_time(time_str)
+
+            image = data.get("image")
+            if image and not image.startswith("http"):
+                image = urljoin(BASE_URL, image)
+
+            link = data.get("link")
+            if link and not link.startswith("http"):
+                link = urljoin(BASE_URL, link)
+
+            if not name or len(name) < 3:
+                return None
+
+            return EventCreate(
+                name=name,
+                time=parsed_time,
+                date=parsed_date,
+                location=location or "Varaždin",
+                description=description or f"Event: {name}",
+                price=price or "Check website",
+                image=image,
+                link=link,
+            )
+        except Exception:
+            return None
+
+
+class VisitVarazdinRequestsScraper:
+    """Scraper using httpx and BeautifulSoup."""
+
+    def __init__(self) -> None:
+        self.client = httpx.AsyncClient(headers=HEADERS)
+
+    async def fetch(self, url: str) -> httpx.Response:
+        if USE_SB and USE_PROXY:
+            params = {"url": url}
+            async with httpx.AsyncClient(headers=HEADERS, auth=(USER, PASSWORD), verify=False) as client:
+                resp = await client.get(SCRAPING_BROWSER_EP, params=params, timeout=30)
+        elif USE_PROXY:
+            async with httpx.AsyncClient(headers=HEADERS, proxies={"http": PROXY, "https": PROXY}, verify=False) as client:
+                resp = await client.get(url, timeout=30)
+        else:
+            async with httpx.AsyncClient(headers=HEADERS) as client:
+                resp = await client.get(url, timeout=30)
+        resp.raise_for_status()
+        return resp
+
+    async def parse_event_detail(self, url: str) -> Dict:
+        resp = await self.fetch(url)
+        soup = BeautifulSoup(resp.text, "html.parser")
+        data: Dict[str, str] = {}
+
+        title_el = soup.select_one("h1")
+        if title_el:
+            data["title"] = title_el.get_text(strip=True)
+
+        desc_el = soup.select_one(".description, .text, article")
+        if desc_el:
+            data["description"] = desc_el.get_text(separator=" ", strip=True)
+
+        date_el = soup.find(string=re.compile(r"\d{4}"))
+        if date_el:
+            data["date"] = date_el.strip()
+
+        time_el = soup.find(string=re.compile(r"\d{1,2}:\d{2}"))
+        if time_el:
+            data["time"] = time_el.strip()
+
+        img_el = soup.select_one("img[src]")
+        if img_el:
+            data["image"] = img_el.get("src")
+
+        loc_el = soup.select_one(".location, .venue, .place")
+        if loc_el:
+            data["location"] = loc_el.get_text(strip=True)
+
+        return data
+
+    def parse_listing_element(self, el: Tag) -> Dict:
+        data: Dict[str, str] = {}
+        link_el = el.select_one("a")
+        if link_el and link_el.get("href"):
+            data["link"] = urljoin(BASE_URL, link_el.get("href"))
+            if link_el.get_text(strip=True):
+                data["title"] = link_el.get_text(strip=True)
+
+        date_el = el.select_one(".date, time")
+        if date_el and date_el.get_text(strip=True):
+            data["date"] = date_el.get_text(strip=True)
+
+        img_el = el.select_one("img")
+        if img_el and img_el.get("src"):
+            data["image"] = img_el.get("src")
+
+        loc_el = el.select_one(".location, .venue, .place")
+        if loc_el:
+            data["location"] = loc_el.get_text(strip=True)
+
+        return data
+
+    async def scrape_events_page(self, url: str) -> Tuple[List[Dict], Optional[str]]:
+        resp = await self.fetch(url)
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+        events: List[Dict] = []
+        containers = []
+        selectors = [
+            "li.event-item",
+            "div.event-item",
+            "article",
+            ".events-list li",
+        ]
+        for sel in selectors:
+            found = soup.select(sel)
+            if found:
+                containers = found
+                break
+
+        for el in containers:
+            if isinstance(el, Tag):
+                data = self.parse_listing_element(el)
+                link = data.get("link")
+                if link:
+                    try:
+                        detail = await self.parse_event_detail(link)
+                        data.update({k: v for k, v in detail.items() if v})
+                    except Exception:
+                        pass
+                if data:
+                    events.append(data)
+
+        next_url = None
+        next_link = soup.select_one('a[rel="next"], .pagination-next a, a.next')
+        if next_link and next_link.get("href"):
+            next_url = urljoin(url, next_link.get("href"))
+
+        return events, next_url
+
+    async def scrape_all_events(self, max_pages: int = 5) -> List[Dict]:
+        all_events: List[Dict] = []
+        current_url = EVENTS_URL
+        page = 0
+        while current_url and page < max_pages:
+            page += 1
+            events, next_url = await self.scrape_events_page(current_url)
+            all_events.extend(events)
+            if not next_url or not events:
+                break
+            current_url = next_url
+            await asyncio.sleep(1)
+        return all_events
+
+    async def close(self) -> None:
+        await self.client.aclose()
+
+
+class VisitVarazdinScraper:
+    """High level scraper for VisitVarazdin.hr."""
+
+    def __init__(self) -> None:
+        self.requests_scraper = VisitVarazdinRequestsScraper()
+        self.transformer = VisitVarazdinEventDataTransformer()
+
+    async def scrape_events(self, max_pages: int = 5) -> List[EventCreate]:
+        raw = await self.requests_scraper.scrape_all_events(max_pages=max_pages)
+        events: List[EventCreate] = []
+        for item in raw:
+            event = self.transformer.transform(item)
+            if event:
+                events.append(event)
+        await self.requests_scraper.close()
+        return events
+
+    def save_events_to_database(self, events: List[EventCreate]) -> int:
+        from sqlalchemy import select, tuple_
+        from sqlalchemy.dialects.postgresql import insert
+
+        from ..core.database import SessionLocal
+        from ..models.event import Event
+
+        if not events:
+            return 0
+
+        db = SessionLocal()
+        try:
+            event_dicts = [e.model_dump() for e in events]
+            pairs = [(e["name"], e["date"]) for e in event_dicts]
+            existing = db.execute(
+                select(Event.name, Event.date).where(tuple_(Event.name, Event.date).in_(pairs))
+            ).all()
+            existing_pairs = set(existing)
+            to_insert = [e for e in event_dicts if (e["name"], e["date"]) not in existing_pairs]
+            if to_insert:
+                stmt = insert(Event).values(to_insert)
+                stmt = stmt.on_conflict_do_nothing(index_elements=["name", "date"])
+                db.execute(stmt)
+                db.commit()
+                return len(to_insert)
+            db.commit()
+            return 0
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+
+async def scrape_visitvarazdin_events(max_pages: int = 5) -> Dict:
+    scraper = VisitVarazdinScraper()
+    try:
+        events = await scraper.scrape_events(max_pages=max_pages)
+        saved = scraper.save_events_to_database(events)
+        return {
+            "status": "success",
+            "scraped_events": len(events),
+            "saved_events": saved,
+            "message": f"Scraped {len(events)} events from VisitVarazdin.hr, saved {saved} new events",
+        }
+    except Exception as e:
+        return {"status": "error", "message": f"VisitVarazdin scraping failed: {e}"}


### PR DESCRIPTION
## Summary
- scrape VisitVarazdin.hr events with Bright Data support
- wire new scraper into enhanced pipeline and API routes
- document new VisitVarazdin endpoints in README

## Testing
- `npm run test` *(fails: ValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_6849e5ac53e48328b16e688d9c4d66e3