### PR TITLE
Add scraper for TZDubrovnik events

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ The backend includes an integrated web scraping system that automatically collec
 - **Entrio.hr** - Croatia's leading event ticketing platform
 - **Croatia.hr** - Official Croatian tourism events portal
 - **InfoZagreb.hr** - Zagreb tourist board event listings
+- **TZDubrovnik.hr** - Dubrovnik tourist board event listings
 
 ### Features
 - **Dual Scraping Approach**: Uses both requests/BeautifulSoup and Playwright for maximum compatibility
@@ -225,6 +226,9 @@ curl -X GET "http://localhost:8000/api/scraping/croatia/quick?max_pages=2"
 # Quick scraping from InfoZagreb.hr (1-3 pages)
 curl -X GET "http://localhost:8000/api/scraping/infozagreb/quick?max_pages=2"
 
+# Quick scraping from TZDubrovnik.hr (1-3 pages)
+curl -X GET "http://localhost:8000/api/scraping/tzdubrovnik/quick?max_pages=2"
+
 # Full scraping from specific site (background task)
 curl -X POST "http://localhost:8000/api/scraping/entrio" \
   -H "Content-Type: application/json" \
@@ -232,6 +236,11 @@ curl -X POST "http://localhost:8000/api/scraping/entrio" \
 
 # Full scraping from InfoZagreb.hr
 curl -X POST "http://localhost:8000/api/scraping/infozagreb" \
+  -H "Content-Type: application/json" \
+  -d '{"max_pages": 5}'
+
+# Full scraping from TZDubrovnik.hr
+curl -X POST "http://localhost:8000/api/scraping/tzdubrovnik" \
   -H "Content-Type: application/json" \
   -d '{"max_pages": 5}'
 
@@ -253,7 +262,7 @@ ENABLE_SCHEDULER=true
 **Schedules:**
 - **Production**: Daily at 02:00 (10 pages per site)
 - **Development**: Hourly (2 pages per site)
-- **Sites**: Entrio.hr, Croatia.hr and InfoZagreb.hr
+- **Sites**: Entrio.hr, Croatia.hr, InfoZagreb.hr and TZDubrovnik.hr
 
 ### Configuration
 
@@ -341,6 +350,8 @@ The backend provides RESTful API endpoints:
 - `GET /api/scraping/croatia/quick` - Quick Croatia.hr scraping (1-3 pages)
 - `POST /api/scraping/infozagreb` - Trigger full InfoZagreb.hr scraping
 - `GET /api/scraping/infozagreb/quick` - Quick InfoZagreb.hr scraping (1-3 pages)
+- `POST /api/scraping/tzdubrovnik` - Trigger full TZDubrovnik.hr scraping
+- `GET /api/scraping/tzdubrovnik/quick` - Quick TZDubrovnik.hr scraping (1-3 pages)
 - `POST /api/scraping/all` - Scrape from all supported sites
 - `GET /api/scraping/status` - Get scraping system status
 

--- a/backend/app/scraping/enhanced_scraper.py
+++ b/backend/app/scraping/enhanced_scraper.py
@@ -15,6 +15,7 @@ from ..models.schemas import EventCreate
 from .croatia_scraper import CroatiaScraper
 from .entrio_scraper import EntrioScraper
 from .infozagreb_scraper import InfoZagrebScraper
+from .tzdubrovnik_scraper import DubrovnikScraper
 from .ulaznice_scraper import UlazniceScraper
 
 
@@ -29,6 +30,7 @@ class EnhancedScrapingPipeline:
         self.entrio_scraper = EntrioScraper()
         self.croatia_scraper = CroatiaScraper()
         self.infozagreb_scraper = InfoZagrebScraper()
+        self.tzdubrovnik_scraper = DubrovnikScraper()
         self.ulaznice_scraper = UlazniceScraper()
 
     async def scrape_all_sources(self, max_pages_per_source: int = 5) -> Dict[str, Any]:
@@ -50,6 +52,7 @@ class EnhancedScrapingPipeline:
             ("entrio.hr", self.entrio_scraper, max_pages_per_source),
             ("croatia.hr", self.croatia_scraper, max_pages_per_source),
             ("infozagreb.hr", self.infozagreb_scraper, max_pages_per_source),
+            ("tzdubrovnik.hr", self.tzdubrovnik_scraper, max_pages_per_source),
             ("ulaznice.hr", self.ulaznice_scraper, max_pages_per_source),
         ]
 
@@ -232,6 +235,8 @@ class EnhancedScrapingPipeline:
             scraper = self.croatia_scraper
         elif source.lower() == "infozagreb":
             scraper = self.infozagreb_scraper
+        elif source.lower() == "tzdubrovnik":
+            scraper = self.tzdubrovnik_scraper
         elif source.lower() == "ulaznice":
             scraper = self.ulaznice_scraper
         else:


### PR DESCRIPTION
## Summary
- add Bright Data proxy support to `InfoZagreb` scraper
- implement new `tzdubrovnik_scraper` using Bright Data
- expose new endpoints in `scraping` routes
- integrate TZDubrovnik into enhanced scraping pipeline
- document new endpoints and site in README

## Testing
- `uv run black app/ --line-length=88`
- `flake8 app/ --max-line-length=88 --extend-ignore=E203,W503` *(fails: numerous style issues)*
- `uv run mypy app/ --ignore-missing-imports` *(fails: many typing errors)*
- `uv run pytest -v` *(fails: settings validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849e5b9f10483288f4f1d0a64e37ef2