### PR TITLE
Add VisitVarazdin scraper

### DIFF
--- a/backend/app/scraping/enhanced_scraper.py
+++ b/backend/app/scraping/enhanced_scraper.py
@@ -21,6 +21,7 @@ from .vukovar_scraper import VukovarScraper
 from .visitsplit_scraper import VisitSplitScraper
 from .zadar_scraper import ZadarScraper
 from .tzdubrovnik_scraper import DubrovnikScraper
+from .visitvarazdin_scraper import VisitVarazdinScraper
 
 
 
@@ -41,6 +42,7 @@ class EnhancedScrapingPipeline:
         self.visitsplit_scraper = VisitSplitScraper()
         self.zadar_scraper = ZadarScraper()
         self.dubrovnik_scraper = DubrovnikScraper()
+        self.visitvarazdin_scraper = VisitVarazdinScraper()
 
     async def scrape_all_sources(self, max_pages_per_source: int = 5) -> Dict[str, Any]:
         """Scrape events from all sources with enhanced quality processing."""
@@ -67,6 +69,7 @@ class EnhancedScrapingPipeline:
             ("visitsplit.com", self.visitsplit_scraper, max_pages_per_source),
             ("zadar.travel", self.zadar_scraper, max_pages_per_source),
             ("tzdubrovnik.hr", self.dubrovnik_scraper, max_pages_per_source),
+            ("visitvarazdin.hr", self.visitvarazdin_scraper, max_pages_per_source),
         ]
         all_scraped_events = []
 
@@ -259,6 +262,8 @@ class EnhancedScrapingPipeline:
             scraper = self.zadar_scraper
         elif source.lower() == "tzdubrovnik":
             scraper = self.dubrovnik_scraper
+        elif source.lower() == "visitvarazdin":
+            scraper = self.visitvarazdin_scraper
         else:
             raise ValueError(f"Unknown source: {source}")
 

--- a/backend/app/scraping/visitvarazdin_scraper.py
+++ b/backend/app/scraping/visitvarazdin_scraper.py
@@ -1,0 +1,350 @@
+"""VisitVarazdin.hr events scraper with optional Bright Data proxy."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from datetime import date
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import urljoin
+
+import httpx
+from bs4 import BeautifulSoup, Tag
+
+from ..models.schemas import EventCreate
+
+# Bright Data configuration shared with other scrapers
+USER = os.getenv("BRIGHTDATA_USER", "demo_user")
+PASSWORD = os.getenv("BRIGHTDATA_PASSWORD", "demo_password")
+BRIGHTDATA_HOST_RES = "brd.superproxy.io"
+BRIGHTDATA_PORT = int(os.getenv("BRIGHTDATA_PORT", 22225))
+SCRAPING_BROWSER_EP = f"https://{BRIGHTDATA_HOST_RES}:{BRIGHTDATA_PORT}"
+PROXY = f"http://{USER}:{PASSWORD}@{BRIGHTDATA_HOST_RES}:{BRIGHTDATA_PORT}"
+
+USE_SB = os.getenv("USE_SCRAPING_BROWSER", "0") == "1"
+USE_PROXY = os.getenv("USE_PROXY", "0") == "1"
+
+BASE_URL = "https://visitvarazdin.hr"
+EVENTS_URL = f"{BASE_URL}/en/events"
+
+HEADERS = {
+    "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 ScraperBot/1.0",
+}
+
+
+class VisitVarazdinTransformer:
+    """Transform raw VisitVarazdin event data to :class:`EventCreate`."""
+
+    CRO_MONTHS = {
+        "january": 1,
+        "february": 2,
+        "march": 3,
+        "april": 4,
+        "may": 5,
+        "june": 6,
+        "july": 7,
+        "august": 8,
+        "september": 9,
+        "october": 10,
+        "november": 11,
+        "december": 12,
+    }
+
+    @staticmethod
+    def parse_date(date_str: str) -> Optional[date]:
+        if not date_str:
+            return None
+        date_str = date_str.strip()
+        patterns = [
+            r"(\d{1,2})\.(\d{1,2})\.(\d{4})",
+            r"(\d{4})-(\d{1,2})-(\d{1,2})",
+            r"(\d{1,2})\s+(\w+)\s*(\d{4})",
+        ]
+        for pattern in patterns:
+            m = re.search(pattern, date_str, re.IGNORECASE)
+            if m:
+                try:
+                    if pattern.startswith("("):
+                        day, month, year = m.groups()
+                        if month.isdigit():
+                            return date(int(year), int(month), int(day))
+                        month_num = VisitVarazdinTransformer.CRO_MONTHS.get(month.lower())
+                        if month_num:
+                            return date(int(year), month_num, int(day))
+                    elif pattern.startswith("(\d{4})"):
+                        year, month, day = m.groups()
+                        return date(int(year), int(month), int(day))
+                except (ValueError, TypeError):
+                    continue
+        year_match = re.search(r"(\d{4})", date_str)
+        if year_match:
+            try:
+                return date(int(year_match.group(1)), 1, 1)
+            except ValueError:
+                pass
+        return None
+
+    @staticmethod
+    def parse_time(time_str: str) -> str:
+        if not time_str:
+            return "20:00"
+        m = re.search(r"(\d{1,2}):(\d{2})", time_str)
+        if m:
+            hour, minute = m.groups()
+            return f"{int(hour):02d}:{minute}"
+        m = re.search(r"(\d{1,2})h", time_str)
+        if m:
+            hour = m.group(1)
+            return f"{int(hour):02d}:00"
+        return "20:00"
+
+    @staticmethod
+    def clean_text(text: str) -> str:
+        return " ".join(text.split()) if text else ""
+
+    @classmethod
+    def transform(cls, data: Dict) -> Optional[EventCreate]:
+        try:
+            name = cls.clean_text(data.get("title", ""))
+            location = cls.clean_text(data.get("location", "Varazdin"))
+            description = cls.clean_text(data.get("description", ""))
+            price = cls.clean_text(data.get("price", ""))
+
+            date_str = data.get("date", "")
+            parsed_date = cls.parse_date(date_str)
+            if not parsed_date:
+                return None
+
+            time_str = data.get("time", "")
+            parsed_time = cls.parse_time(time_str)
+
+            image = data.get("image")
+            if image and not image.startswith("http"):
+                image = urljoin(BASE_URL, image)
+
+            link = data.get("link")
+            if link and not link.startswith("http"):
+                link = urljoin(BASE_URL, link)
+
+            if not name or len(name) < 3:
+                return None
+
+            return EventCreate(
+                name=name,
+                time=parsed_time,
+                date=parsed_date,
+                location=location or "Varazdin",
+                description=description or f"Event: {name}",
+                price=price or "Check website",
+                image=image,
+                link=link,
+            )
+        except Exception:
+            return None
+
+
+class VisitVarazdinRequestsScraper:
+    """Scraper using httpx and BeautifulSoup with optional Bright Data proxy."""
+
+    def __init__(self) -> None:
+        if USE_PROXY and not USE_SB:
+            self.client = httpx.AsyncClient(
+                headers=HEADERS,
+                proxies={"http": PROXY, "https": PROXY},
+                verify=False,
+            )
+        else:
+            self.client = httpx.AsyncClient(headers=HEADERS)
+
+    async def fetch(self, url: str) -> httpx.Response:
+        if USE_SB and USE_PROXY:
+            params = {"url": url}
+            resp = await self.client.get(
+                SCRAPING_BROWSER_EP,
+                params=params,
+                auth=(USER, PASSWORD),
+                timeout=30,
+                verify=False,
+            )
+        else:
+            resp = await self.client.get(url, timeout=30)
+        resp.raise_for_status()
+        return resp
+
+    async def parse_event_detail(self, url: str) -> Dict:
+        resp = await self.fetch(url)
+        soup = BeautifulSoup(resp.text, "html.parser")
+        data: Dict[str, str] = {}
+
+        title_el = soup.select_one("h1")
+        if title_el:
+            data["title"] = title_el.get_text(strip=True)
+
+        desc_el = soup.select_one(".description, .text, article")
+        if desc_el:
+            data["description"] = desc_el.get_text(separator=" ", strip=True)
+
+        date_el = soup.find(string=re.compile(r"\d{4}"))
+        if date_el:
+            data["date"] = date_el.strip()
+
+        time_el = soup.find(string=re.compile(r"\d{1,2}:\d{2}"))
+        if time_el:
+            data["time"] = time_el.strip()
+
+        img_el = soup.select_one("img[src]")
+        if img_el:
+            data["image"] = img_el.get("src")
+
+        loc_el = soup.select_one(".location, .venue, .place")
+        if loc_el:
+            data["location"] = loc_el.get_text(strip=True)
+
+        price_el = soup.select_one(".price")
+        if price_el:
+            data["price"] = price_el.get_text(strip=True)
+
+        return data
+
+    def parse_listing_element(self, el: Tag) -> Dict:
+        data: Dict[str, str] = {}
+        link_el = el.select_one("a")
+        if link_el and link_el.get("href"):
+            data["link"] = urljoin(BASE_URL, link_el.get("href"))
+            if link_el.get_text(strip=True):
+                data["title"] = link_el.get_text(strip=True)
+
+        date_el = el.select_one(".date, time")
+        if date_el and date_el.get_text(strip=True):
+            data["date"] = date_el.get_text(strip=True)
+
+        img_el = el.select_one("img")
+        if img_el and img_el.get("src"):
+            data["image"] = img_el.get("src")
+
+        loc_el = el.select_one(".location, .venue, .place")
+        if loc_el:
+            data["location"] = loc_el.get_text(strip=True)
+
+        price_el = el.select_one(".price")
+        if price_el:
+            data["price"] = price_el.get_text(strip=True)
+
+        return data
+
+    async def scrape_events_page(self, url: str) -> Tuple[List[Dict], Optional[str]]:
+        resp = await self.fetch(url)
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+        events: List[Dict] = []
+        containers: List[Tag] = []
+        selectors = ["li.event-item", "div.event-item", "article", ".events-list li"]
+        for sel in selectors:
+            found = soup.select(sel)
+            if found:
+                containers = found
+                break
+
+        for el in containers:
+            if isinstance(el, Tag):
+                data = self.parse_listing_element(el)
+                link = data.get("link")
+                if link:
+                    try:
+                        detail = await self.parse_event_detail(link)
+                        data.update({k: v for k, v in detail.items() if v})
+                    except Exception:
+                        pass
+                if data:
+                    events.append(data)
+
+        next_url = None
+        next_link = soup.select_one('a[rel="next"], .pagination-next a, a.next')
+        if next_link and next_link.get("href"):
+            next_url = urljoin(url, next_link.get("href"))
+
+        return events, next_url
+
+    async def scrape_all_events(self, max_pages: int = 5) -> List[Dict]:
+        all_events: List[Dict] = []
+        current_url = EVENTS_URL
+        page = 0
+        while current_url and page < max_pages:
+            page += 1
+            events, next_url = await self.scrape_events_page(current_url)
+            all_events.extend(events)
+            if not next_url or not events:
+                break
+            current_url = next_url
+            await asyncio.sleep(1)
+        return all_events
+
+    async def close(self) -> None:
+        await self.client.aclose()
+
+
+class VisitVarazdinScraper:
+    """High level scraper for VisitVarazdin.hr."""
+
+    def __init__(self) -> None:
+        self.requests_scraper = VisitVarazdinRequestsScraper()
+        self.transformer = VisitVarazdinTransformer()
+
+    async def scrape_events(self, max_pages: int = 5) -> List[EventCreate]:
+        raw = await self.requests_scraper.scrape_all_events(max_pages=max_pages)
+        events: List[EventCreate] = []
+        for item in raw:
+            event = self.transformer.transform(item)
+            if event:
+                events.append(event)
+        await self.requests_scraper.close()
+        return events
+
+    def save_events_to_database(self, events: List[EventCreate]) -> int:
+        from sqlalchemy import select, tuple_
+        from sqlalchemy.dialects.postgresql import insert
+
+        from ..core.database import SessionLocal
+        from ..models.event import Event
+
+        if not events:
+            return 0
+
+        db = SessionLocal()
+        try:
+            event_dicts = [e.model_dump() for e in events]
+            pairs = [(e["name"], e["date"]) for e in event_dicts]
+            existing = db.execute(
+                select(Event.name, Event.date).where(tuple_(Event.name, Event.date).in_(pairs))
+            ).all()
+            existing_pairs = set(existing)
+            to_insert = [e for e in event_dicts if (e["name"], e["date"]) not in existing_pairs]
+            if to_insert:
+                stmt = insert(Event).values(to_insert)
+                stmt = stmt.on_conflict_do_nothing(index_elements=["name", "date"])
+                db.execute(stmt)
+                db.commit()
+                return len(to_insert)
+            db.commit()
+            return 0
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+
+async def scrape_visitvarazdin_events(max_pages: int = 5) -> Dict:
+    scraper = VisitVarazdinScraper()
+    try:
+        events = await scraper.scrape_events(max_pages=max_pages)
+        saved = scraper.save_events_to_database(events)
+        return {
+            "status": "success",
+            "scraped_events": len(events),
+            "saved_events": saved,
+            "message": f"Scraped {len(events)} events from VisitVarazdin.hr, saved {saved} new events",
+        }
+    except Exception as e:
+        return {"status": "error", "message": f"VisitVarazdin scraping failed: {e}"}

--- a/backend/scripts/test_visitvarazdin_scraper.py
+++ b/backend/scripts/test_visitvarazdin_scraper.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Test script for VisitVarazdin.hr scraper."""
+
+import asyncio
+import sys
+import os
+import json
+from datetime import datetime
+import pytest
+
+# Add parent directory to import app modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from app.scraping.visitvarazdin_scraper import VisitVarazdinScraper
+
+
+@pytest.mark.asyncio
+async def test_visitvarazdin_scraper():
+    """Basic test for the VisitVarazdin scraper."""
+    print("=" * 60)
+    print("VisitVarazdin.hr Scraper Test")
+    print("=" * 60)
+
+    scraper = VisitVarazdinScraper()
+
+    try:
+        print("Starting VisitVarazdin scraper test (max 1 page)...")
+        events = await scraper.scrape_events(max_pages=1)
+        print(f"\n✅ Scraping completed: {len(events)} events")
+
+        assert isinstance(events, list)
+
+        if events:
+            first = events[0]
+            print("Sample event:")
+            print(f"  Name: {first.name}")
+            print(f"  Date: {first.date}")
+            print(f"  Location: {first.location}")
+            print(f"  Link: {first.link}")
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"visitvarazdin_scraper_test_{timestamp}.json"
+        with open(filename, "w", encoding="utf-8") as f:
+            json.dump([e.model_dump() for e in events[:5]], f, ensure_ascii=False, indent=2)
+        print(f"\nSaved sample data to {filename}")
+    except Exception as e:
+        print(f"Scraper failed: {e}")
+        return False
+
+    return True
+
+
+if __name__ == "__main__":
+    success = asyncio.run(test_visitvarazdin_scraper())
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary
- add VisitVarazdin scraper with Bright Data support
- integrate VisitVarazdin scraper into enhanced scraping pipeline
- provide simple test script for the new scraper

## Testing
- `pytest backend/scripts/test_visitvarazdin_scraper.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684a6f4cd6b883288fde1a225da8e25e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for scraping events from the VisitVarazdin.hr website, including event details such as title, date, time, location, and more.
  - Integrated the new VisitVarazdin source into the event aggregation pipeline.

- **Tests**
  - Introduced a new test script to verify the functionality of the VisitVarazdin.hr scraper, including event extraction and data validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->