### PR TITLE
Connect map page to events

### DIFF
--- a/frontend/src/components/AppContent.tsx
+++ b/frontend/src/components/AppContent.tsx
@@ -7,6 +7,7 @@ import About from "../pages/About";
 import Venues from "../pages/Venues";
 import Favorites from "../pages/Favorites";
 import Popular from "../pages/Popular";
+import MapPage from "../pages/Map";
 import Admin from "../pages/Admin";
 import CreateEvent from "../pages/CreateEvent";
 import OrganizerDashboard from "../pages/OrganizerDashboard";
@@ -24,6 +25,7 @@ const AppContent = () => {
         <Route path="/venues" element={<Venues />} />
         <Route path="/favorites" element={<Favorites />} />
         <Route path="/popular" element={<Popular />} />
+        <Route path="/map" element={<MapPage />} />
         <Route path="/admin" element={<Admin />} />
         <Route path="/create-event" element={<CreateEvent />} />
         <Route path="/organizer/dashboard" element={<OrganizerDashboard />} />

--- a/frontend/src/components/EventMap.tsx
+++ b/frontend/src/components/EventMap.tsx
@@ -28,6 +28,7 @@ import {
   Coordinates,
 } from "@/lib/geocoding";
 import { logger } from "@/lib/logger";
+import { cn } from "@/lib/utils";
 
 // Event category mapping and icons
 const categoryConfig = {
@@ -48,7 +49,11 @@ interface MapEvent extends Event {
   coordinates?: Coordinates;
 }
 
-const EventMap = () => {
+interface EventMapProps {
+  className?: string;
+}
+
+const EventMap: React.FC<EventMapProps> = ({ className }) => {
   const mapContainer = useRef<HTMLDivElement>(null);
   const map = useRef<mapboxgl.Map | null>(null);
   const markersRef = useRef<mapboxgl.Marker[]>([]);
@@ -297,7 +302,7 @@ const EventMap = () => {
 
 
   return (
-    <div className="relative w-full h-screen">
+    <div className={cn("relative w-full h-screen", className)}>
       {/* Map Container */}
       <div ref={mapContainer} className="w-full h-full" />
 

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import Header from "@/components/Header";
-import EventMapDemo from "@/components/EventMapDemo";
+import EventMap from "@/components/EventMap";
 import FeaturedEvents from "@/components/FeaturedEvents";
 import LatestNews from "@/components/LatestNews";
 import AboutCroatia from "@/components/AboutCroatia";
@@ -130,7 +130,7 @@ const Index = () => {
               {t("home.map.title")}
             </h2>
 
-            <EventMapDemo />
+            <EventMap className="h-[600px]" />
           </section>
 
           <FeaturedEvents />

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import EventMap from "@/components/EventMap";
+import PageTransition from "@/components/PageTransition";
+
+const MapPage = () => {
+  return (
+    <PageTransition>
+      <div className="min-h-screen flex flex-col bg-cream dark:bg-gray-900 transition-colors duration-300">
+        <Header />
+        <main className="flex-grow">
+          <EventMap />
+        </main>
+        <Footer />
+      </div>
+    </PageTransition>
+  );
+};
+
+export default MapPage;


### PR DESCRIPTION
## Summary
- add `className` prop to `EventMap` for flexible sizing
- hook Map page into router and create new `/map` page
- show real EventMap on the homepage

## Testing
- `npm test` *(fails: ValidationError during pytest collection)*

------
https://chatgpt.com/codex/tasks/task_e_684b03a1cf7c83288d7eaf9aaafb2e57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated map page accessible via the `/map` route, featuring a full-page interactive map with header and footer.
- **Enhancements**
  - Improved map component to support custom styling through an optional class name.
  - Updated the homepage to use the main map component with a specified height for better layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->