### PR TITLE
Enable user submitted events

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ The backend provides RESTful API endpoints:
 - `POST /api/events` - Create new event
 - `PUT /api/events/{id}` - Update event
 - `DELETE /api/events/{id}` - Delete event
+- `POST /api/user-events/create` - Submit a user-generated event (authentication required; new events are marked as pending until reviewed)
 
 ### Scraping
 - `POST /api/scraping/entrio` - Trigger full Entrio.hr scraping

--- a/backend/app/routes/user_events.py
+++ b/backend/app/routes/user_events.py
@@ -114,10 +114,8 @@ def create_user_event(
 ):
     """Create a new user-generated event."""
     try:
-        require_event_creator(
-            current_user,
-            "You need to be a venue owner or manager to create events. Please contact support to upgrade your account.",
-        )
+        # Any authenticated user can submit events. The event will be marked as
+        # user generated and require admin approval before it becomes public.
 
         # Validate category exists
         category = (


### PR DESCRIPTION
## Summary
- allow any logged-in user to create events
- document new `/api/user-events/create` endpoint in README

## Testing
- `npm run test` *(fails: pydantic validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b226b3540832887cd323009470b74