### PR TITLE
Add production Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Ignore node and python caches
+node_modules
+frontend/node_modules
+backend/.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.log
+*.sqlite3
+dist
+frontend/dist
+coverage

--- a/README.md
+++ b/README.md
@@ -443,6 +443,21 @@ npm run build
 # Serve the dist/ directory with your preferred web server
 ```
 
+### Docker Deployment
+
+Build a single image that bundles the frontend, backend and nginx:
+
+```bash
+# Build the production image
+docker build -t kruzna-karta-prod -f docker-prod/Dockerfile .
+
+# Run the container
+docker run -d -p 80:80 --env-file .env kruzna-karta-prod
+```
+
+The container exposes port `80` and serves both the API and the UI. Adjust the
+`.env` file for your production settings before building the image.
+
 ## 🛠️ Development
 
 ### Adding New Features

--- a/docker-prod/Dockerfile
+++ b/docker-prod/Dockerfile
@@ -1,0 +1,39 @@
+# Multi-stage Dockerfile for production deployment
+
+# --- Build frontend ---
+FROM node:18 AS frontend-build
+WORKDIR /frontend
+COPY frontend/package*.json ./
+RUN npm install
+COPY frontend .
+RUN npm run build
+
+# --- Build backend ---
+FROM python:3.11-slim AS backend-build
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential curl git && rm -rf /var/lib/apt/lists/*
+RUN pip install uv
+WORKDIR /app
+COPY backend/pyproject.toml backend/uv.lock ./
+RUN uv venv /app/.venv && uv sync
+ENV PATH="/app/.venv/bin:$PATH"
+COPY backend/app ./app
+
+# --- Final image ---
+FROM python:3.11-slim
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+RUN apt-get update && apt-get install -y --no-install-recommends nginx \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip install uv
+COPY --from=backend-build /app /app
+COPY --from=frontend-build /frontend/dist /usr/share/nginx/html
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY nginx/conf.d /etc/nginx/conf.d
+COPY docker-prod/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+WORKDIR /app
+EXPOSE 80
+CMD ["/entrypoint.sh"]

--- a/docker-prod/entrypoint.sh
+++ b/docker-prod/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Start the backend in the background
+uvicorn app.main:app --host 0.0.0.0 --port 8000 &
+
+# Start nginx in the foreground
+exec nginx -g 'daemon off;'


### PR DESCRIPTION
## Summary
- add `.dockerignore`
- create `docker-prod` directory with Dockerfile and entrypoint script
- document Docker image build and run in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684bdfa1e89083288d2ee7c968b2d911

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a production-ready Docker setup that builds and serves both the frontend and backend within a single container using nginx.
  - Introduced a shell script to automatically start both the backend server and nginx when the container launches.

- **Documentation**
  - Updated the README with step-by-step instructions for deploying the application using Docker.

- **Chores**
  - Added a .dockerignore file to optimize Docker builds by excluding unnecessary files and directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->