### PR TITLE
Add personalized event recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The backend includes an integrated web scraping system that automatically collec
 - **Automatic Data Processing**: Transforms scraped data to match database schema
 - **Duplicate Prevention**: Automatically detects and prevents duplicate events
 - **Scheduled Tasks**: Optional automatic scraping at configurable intervals
+- **Personalized Recommendations**: Suggests events based on user history
 
 ### Usage
 

--- a/backend/app/core/recommendation.py
+++ b/backend/app/core/recommendation.py
@@ -1,0 +1,97 @@
+"""Simple recommendation engine for suggesting events to users."""
+
+from datetime import date
+from typing import Any, Dict, List
+
+from fastapi import Depends
+from sqlalchemy import desc, func
+from sqlalchemy.orm import Session
+
+from ..models.analytics import EventView, SearchLog, UserInteraction
+from ..models.event import Event
+from ..models.user import user_favorites
+from .database import get_db
+from .performance import PerformanceService
+
+
+class RecommendationService:
+    """Provide event recommendations for a user based on history."""
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.performance = PerformanceService(db)
+
+    def _get_user_history_event_ids(self, user_id: int) -> List[int]:
+        """Collect event ids the user interacted with."""
+        viewed = (
+            self.db.query(EventView.event_id)
+            .filter(EventView.user_id == user_id)
+            .distinct()
+            .all()
+        )
+        favorited = (
+            self.db.query(user_favorites.c.event_id)
+            .filter(user_favorites.c.user_id == user_id)
+            .all()
+        )
+        clicked = (
+            self.db.query(SearchLog.clicked_event_id)
+            .filter(SearchLog.user_id == user_id, SearchLog.clicked_event_id.isnot(None))
+            .all()
+        )
+        shared = (
+            self.db.query(UserInteraction.entity_id)
+            .filter(
+                UserInteraction.user_id == user_id,
+                UserInteraction.entity_type == "event",
+                UserInteraction.interaction_type.in_(["share", "favorite"]),
+            )
+            .all()
+        )
+
+        ids = {eid for (eid,) in viewed}
+        ids.update(eid for (eid,) in favorited)
+        ids.update(eid for (eid,) in clicked)
+        ids.update(eid for (eid,) in shared)
+        return list(ids)
+
+    def get_recommendations(self, user_id: int, limit: int = 10, language: str = "hr") -> List[Dict[str, Any]]:
+        """Return recommended events for the user."""
+        history_ids = self._get_user_history_event_ids(user_id)
+
+        if not history_ids:
+            # Fallback to popular events if no history
+            return self.performance.get_popular_events_optimized(limit=limit, language=language)
+
+        # Determine top categories from history
+        category_counts = (
+            self.db.query(Event.category_id, func.count(Event.id).label("cnt"))
+            .filter(Event.id.in_(history_ids))
+            .group_by(Event.category_id)
+            .order_by(desc("cnt"))
+            .limit(3)
+            .all()
+        )
+        category_ids = [cid for cid, _ in category_counts if cid is not None]
+
+        query = (
+            self.db.query(Event)
+            .filter(
+                Event.category_id.in_(category_ids),
+                Event.id.notin_(history_ids),
+                Event.event_status == "active",
+                Event.date >= date.today(),
+            )
+            .order_by(desc(Event.view_count), desc(Event.created_at))
+            .limit(limit)
+        )
+        events = query.all()
+
+        if language != "hr":
+            events = self.performance._apply_translations(events, language)
+
+        return [self.performance._serialize_event(event) for event in events]
+
+
+def get_recommendation_service(db: Session = Depends(get_db)) -> RecommendationService:
+    return RecommendationService(db)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from .routes import (
     scraping_router,
     social_router,
     system_test_router,
+    recommendations_router,
     translations_router,
     user_events_router,
     users_router,
@@ -106,6 +107,7 @@ app.include_router(venue_management_router, prefix="/api")
 app.include_router(social_router, prefix="/api")
 app.include_router(user_events_router, prefix="/api")
 app.include_router(system_test_router, prefix="/api")
+app.include_router(recommendations_router, prefix="/api")
 app.include_router(stripe_webhooks_router, prefix="/api")
 
 

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -12,6 +12,7 @@ from .recurring_events import router as recurring_events_router
 from .scraping import router as scraping_router
 from .social import router as social_router
 from .system_test import router as system_test_router
+from .recommendations import router as recommendations_router
 from .translations import router as translations_router
 from .user_events import router as user_events_router
 from .users import router as users_router
@@ -38,4 +39,5 @@ __all__ = [
     "social_router",
     "user_events_router",
     "system_test_router",
+    "recommendations_router",
 ]

--- a/backend/app/routes/recommendations.py
+++ b/backend/app/routes/recommendations.py
@@ -1,0 +1,20 @@
+"""API routes for event recommendations."""
+
+from fastapi import APIRouter, Depends, Query
+
+from ..core.auth import get_current_active_user
+from ..core.recommendation import RecommendationService, get_recommendation_service
+from ..models.user import User
+
+router = APIRouter(prefix="/recommendations", tags=["recommendations"])
+
+
+@router.get("/events")
+def get_recommended_events(
+    limit: int = Query(10, ge=1, le=50),
+    language: str = Query("hr"),
+    current_user: User = Depends(get_current_active_user),
+    service: RecommendationService = Depends(get_recommendation_service),
+):
+    """Return recommended events for the current user."""
+    return service.get_recommendations(current_user.id, limit=limit, language=language)

--- a/docs/premium-analytics-plan.md
+++ b/docs/premium-analytics-plan.md
@@ -15,6 +15,7 @@ This document proposes a high level plan for enabling paid users to access advan
 - **Engagement Metrics**: Display page views, search analytics and user interactions for each event.
 - **Conversion Analytics**: Track views-to-bookings ratios and highlight high performing events.
 - **Geographic Breakdown**: Summarise revenue and bookings by location using Mapbox visualisations.
+- **Recommendation Engine**: Suggest relevant upcoming events based on attendee behaviour.
 
 ### 2. Event Organisation Tools
 - **Schedule Planner**: Calendar view of all upcoming events with drag-and-drop rescheduling.


### PR DESCRIPTION
## Summary
- implement simple recommendation service that suggests events based on user history
- expose `/recommendations/events` endpoint
- document the feature in README and premium analytics plan

## Testing
- `uv run flake8 app/` *(fails: command not found)*
- `uv run mypy app/ --ignore-missing-imports` *(fails: many typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c1d5b4c2c8328a98748fa19f149bb