### PR TITLE
Implement platform commission rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,13 @@ uv run alembic upgrade head
 2. Add the language code to the `Language` type in `frontend/src/contexts/LanguageContext.tsx`.
 3. Provide a UI option for switching to the new language.
 
+## 💵 Platform Commission on Bookings
+
+Every ticket purchase processed through the platform includes a small
+commission fee. The percentage is configurable via the `platform_commission_rate`
+setting in `.env` (default is **5%**). The backend calculates this commission
+for each booking and passes the amount to Stripe during payment processing.
+
 ## 📈 Premium Analytics for Paid Users
 
 We plan to introduce advanced analytics and event organisation tools for organisers on a paid subscription. See [docs/premium-analytics-plan.md](docs/premium-analytics-plan.md) for details.

--- a/backend/app/core/booking.py
+++ b/backend/app/core/booking.py
@@ -105,10 +105,12 @@ class BookingService:
             unit_price = ticket_type.price
             total_price = unit_price * quantity
 
-            # Get commission rate for user-generated events
-            commission_rate = Decimal("0.0")  # Default no commission
-            if ticket_type.event.is_user_generated:
-                commission_rate = ticket_type.event.platform_commission_rate / 100
+            # Determine commission rate (event value overrides global setting)
+            event_rate = ticket_type.event.platform_commission_rate
+            if event_rate is None:
+                event_rate = settings.platform_commission_rate
+
+            commission_rate = Decimal(str(event_rate)) / Decimal("100")
 
             platform_commission = total_price * commission_rate
             organizer_revenue = total_price - platform_commission


### PR DESCRIPTION
## Summary
- apply global commission rate to all bookings
- document the fee in README

## Testing
- `uv run black app/core/booking.py --line-length=88`
- `uv run isort app/core/booking.py --profile=black`
- `uv run flake8 app/ --max-line-length=88 --extend-ignore=E203,W503` *(fails: many existing style issues)*
- `uv run mypy app/ --ignore-missing-imports` *(fails: numerous type errors)*
- `uv run pytest -v` *(fails: missing env settings)*

------
https://chatgpt.com/codex/tasks/task_e_684d4a21fdc88328be9d2501e06731b0