### PR TITLE
Add third-party API access plan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,4 @@ BRIGHTDATA_PASSWORD=your-brightdata-password
 # Frontend
 VITE_API_BASE_URL=http://localhost:8000/api
 VITE_MAPBOX_ACCESS_TOKEN=your_mapbox_token_here
+THIRD_PARTY_API_KEYS=your_api_key_here

--- a/README.md
+++ b/README.md
@@ -518,6 +518,10 @@ via `aggregate_platform_metrics` so historical reports include these events.
 
 We plan to introduce advanced analytics and event organisation tools for organisers on a paid subscription. See [docs/premium-analytics-plan.md](docs/premium-analytics-plan.md) for details.
 
+## 🗃️ Paid API & Data Export
+
+Third parties such as travel agencies can access curated event data and analytics through a subscription-based API. See [docs/third-party-data-access-plan.md](docs/third-party-data-access-plan.md) for the proposed design.
+
 ## 🤝 Contributing
 
 1. Fork the repository

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -54,6 +54,9 @@ class Settings(BaseSettings):
     currency: str = "EUR"
     payment_methods: list[str] = ["card", "sepa_debit"]  # Supported payment methods
 
+    # Third-party API keys (comma separated)
+    third_party_api_keys: Optional[str] = None
+
     class Config:
         env_file = ".env"
         case_sensitive = False

--- a/backend/app/core/third_party.py
+++ b/backend/app/core/third_party.py
@@ -1,0 +1,21 @@
+import os
+from typing import List
+
+from fastapi import Header, HTTPException, status
+
+from .config import settings
+
+
+def get_valid_api_keys() -> List[str]:
+    keys = settings.third_party_api_keys or os.getenv("THIRD_PARTY_API_KEYS", "")
+    return [k.strip() for k in keys.split(",") if k.strip()]
+
+
+def verify_api_key(x_api_key: str = Header(..., alias="X-API-Key")) -> str:
+    valid_keys = get_valid_api_keys()
+    if x_api_key not in valid_keys:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid API key",
+        )
+    return x_api_key

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,6 +30,7 @@ from .routes import (
     social_router,
     system_test_router,
     recommendations_router,
+    third_party_router,
     translations_router,
     user_events_router,
     users_router,
@@ -108,6 +109,7 @@ app.include_router(social_router, prefix="/api")
 app.include_router(user_events_router, prefix="/api")
 app.include_router(system_test_router, prefix="/api")
 app.include_router(recommendations_router, prefix="/api")
+app.include_router(third_party_router, prefix="/api")
 app.include_router(stripe_webhooks_router, prefix="/api")
 
 

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -13,6 +13,7 @@ from .scraping import router as scraping_router
 from .social import router as social_router
 from .system_test import router as system_test_router
 from .recommendations import router as recommendations_router
+from .third_party import router as third_party_router
 from .translations import router as translations_router
 from .user_events import router as user_events_router
 from .users import router as users_router
@@ -40,4 +41,5 @@ __all__ = [
     "user_events_router",
     "system_test_router",
     "recommendations_router",
+    "third_party_router",
 ]

--- a/backend/app/routes/third_party.py
+++ b/backend/app/routes/third_party.py
@@ -1,0 +1,103 @@
+from datetime import date, timedelta
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import and_, desc, func
+from sqlalchemy.orm import Session
+
+from ..core.database import get_db
+from ..core.third_party import verify_api_key
+from ..core.analytics import AnalyticsService
+from ..models.analytics import PlatformMetrics
+from ..models.event import Event
+from ..models.schemas import EventResponse
+
+router = APIRouter(prefix="/third-party", tags=["third-party"])
+
+
+@router.get("/events", response_model=EventResponse)
+def third_party_events(
+    date_from: Optional[date] = Query(None),
+    date_to: Optional[date] = Query(None),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    api_key: str = Depends(verify_api_key),
+):
+    """Return upcoming events for partners."""
+    query = db.query(Event).filter(Event.status == "active")
+    if date_from:
+        query = query.filter(Event.date >= date_from)
+    if date_to:
+        query = query.filter(Event.date <= date_to)
+    total = query.count()
+    events = query.order_by(Event.date).offset((page - 1) * size).limit(size).all()
+    return EventResponse(total=total, page=page, size=size, events=events)
+
+
+@router.get("/analytics/summary")
+def third_party_platform_summary(
+    date_from: Optional[date] = Query(None),
+    date_to: Optional[date] = Query(None),
+    db: Session = Depends(get_db),
+    api_key: str = Depends(verify_api_key),
+):
+    """Return aggregated platform metrics without personal data."""
+    if not date_from:
+        date_from = date.today() - timedelta(days=30)
+    if not date_to:
+        date_to = date.today()
+
+    metrics = (
+        db.query(PlatformMetrics)
+        .filter(
+            PlatformMetrics.date >= date_from,
+            PlatformMetrics.date <= date_to,
+            PlatformMetrics.metric_type == "daily",
+        )
+        .order_by(PlatformMetrics.date)
+        .all()
+    )
+
+    if not metrics:
+        return {
+            "date_from": date_from,
+            "date_to": date_to,
+            "message": "No metrics available for the specified period",
+        }
+
+    latest = metrics[-1]
+    total_page_views = sum(m.total_page_views for m in metrics)
+    total_searches = sum(m.total_searches for m in metrics)
+    avg_bounce_rate = sum(m.bounce_rate for m in metrics) / len(metrics)
+
+    return {
+        "date_from": date_from,
+        "date_to": date_to,
+        "summary": {
+            "total_users": latest.total_users,
+            "total_events": latest.total_events,
+            "featured_events": latest.featured_events,
+            "total_page_views": total_page_views,
+            "total_searches": total_searches,
+            "avg_bounce_rate": round(avg_bounce_rate, 2),
+        },
+    }
+
+
+@router.get("/analytics/popular-events")
+def third_party_popular_events(
+    date_from: Optional[date] = Query(None),
+    date_to: Optional[date] = Query(None),
+    limit: int = Query(10, ge=1, le=50),
+    db: Session = Depends(get_db),
+    api_key: str = Depends(verify_api_key),
+):
+    """Return top events by view count."""
+    service = AnalyticsService(db)
+    popular = service.get_popular_events(
+        date_from=date_from,
+        date_to=date_to,
+        limit=limit,
+    )
+    return {"results": popular}

--- a/docs/third-party-data-access-plan.md
+++ b/docs/third-party-data-access-plan.md
@@ -1,0 +1,50 @@
+# Third-Party Data Access Plan
+
+This document outlines a proposal for exposing curated event data and analytics to external partners through a paid API and data export service.
+
+## Goals
+
+1. Provide a secure interface for travel agencies, marketing firms and other partners to integrate event listings and aggregated statistics.
+2. Offer granular access controls and usage limits tied to subscription plans.
+3. Reuse existing FastAPI infrastructure with minimal disruption to the main platform.
+
+## Key Features
+
+### 1. API Authentication
+- Partners receive an API key after subscribing.
+- Keys are validated via the `X-API-Key` header on each request.
+- API keys can be revoked or rotated from the admin dashboard.
+
+### 2. Event Data Endpoints
+- `GET /api/third-party/events` – returns upcoming events with optional date range filters.
+- `GET /api/third-party/events/{id}` – fetch a single event with translated fields.
+- Pagination and basic filtering (category, city, etc.) mirror the public `/events` API.
+
+### 3. Analytics Reports
+- `GET /api/third-party/analytics/summary` – aggregated platform metrics over a specified period.
+- `GET /api/third-party/analytics/popular-events` – top events by view count.
+- Response shapes match the internal analytics routes but exclude personal data.
+
+### 4. Data Export
+- Partners can request CSV exports via `GET /api/third-party/export/events.csv`.
+- Exports are generated on demand and cached for short periods.
+
+### 5. Rate Limiting & Billing
+- Each API key has a monthly request quota.
+- Usage is tracked in the database and surfaced in the admin panel.
+- Exceeding the quota returns HTTP `429 Too Many Requests`.
+
+## Implementation Steps
+
+1. Add `THIRD_PARTY_API_KEYS` to `.env` and `Settings`.
+2. Create `ThirdPartyAuth` dependency to validate the API key.
+3. Implement new FastAPI router `third_party.py` with read‑only endpoints for events and analytics.
+4. Register the router in `app.main` under the `/api` prefix.
+5. Document sample requests and response formats.
+
+## Future Ideas
+
+- OAuth application registration for partners instead of static keys.
+- Webhooks for real‑time event updates.
+- Dashboard where partners can monitor their usage statistics.
+


### PR DESCRIPTION
## Summary
- document data export service for external partners
- support third-party API keys in backend settings and example env
- implement basic `/third-party` API routes
- expose router in FastAPI application and docs reference

## Testing
- `npm run test:backend` *(fails: pydantic ValidationError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684d4de555e883289b7c9d6583589297